### PR TITLE
Better error reporting when compiling less files

### DIFF
--- a/src/Bundler/Processor/js/lessc.js
+++ b/src/Bundler/Processor/js/lessc.js
@@ -6,8 +6,9 @@ function compile(source) {
         "filename": path.resolve(process.argv[2])
     }, function (error, output) {
         if (null !== error) {
-            process.stdout.write(error.message);
-            process.stdout.write("\n");
+            console.error(error.message);
+            console.error('In', error.filename, 'on line', error.line);
+            console.error('Near ', error.extract);
 
             process.exit(1);
         }


### PR DESCRIPTION
- Output is now sent to stderr instead of stdout
- Adjusted message

Original:
```
.bla is undefined
```

Now:
```
.bla is undefined
In /path/to/my/file.less on line 15
Near  [ '/* Some code */',
  '.foo::before { .bla(); }',
  '.foo-0-bar::before { content: "0"; }' ]
```