### PR TITLE
Fixed regex for multi line import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ package-lock.json
 composer.lock
 yarn.lock
 composer.phar
+/test/Bundler/dev/104a7_dev.require.js.sources

--- a/src/Import/BuiltIn/TsImportCollector.php
+++ b/src/Import/BuiltIn/TsImportCollector.php
@@ -39,7 +39,7 @@ final class TsImportCollector implements ImportCollectorInterface
     public function collect(string $cwd, File $file, ImportCollection $imports): void
     {
         $content = file_get_contents($cwd . '/' . $file->path);
-        $n       = preg_match_all('/import(.*from)?\s+["\'](.*)["\'];/', $content, $matches);
+        $n       = preg_match_all('/import([^;\'"]*from)?\s+["\'](.*?)["\'];/', $content, $matches);
 
         $this->js_import_collector->collect($cwd, $file, $imports);
 

--- a/test/Bundler/dev/104a7_dev.require.js.sources
+++ b/test/Bundler/dev/104a7_dev.require.js.sources
@@ -1,1 +1,0 @@
-a:1:{i:0;s:63:"/home/ydelange/projects/libs/asset-lib/src/Resources/require.js";}

--- a/test/Import/BuiltIn/TsImportCollectorTest.php
+++ b/test/Import/BuiltIn/TsImportCollectorTest.php
@@ -71,6 +71,7 @@ class TsImportCollectorTest extends TestCase
             new Import('./Alias', new File('resolver/ts/import-syntax/Alias.ts')),
             new Import('./All', new File('resolver/ts/import-syntax/All.ts')),
             new Import('./Multiple', new File('resolver/ts/import-syntax/Multiple.ts')),
+            new Import('./Multiple2', new File('resolver/ts/import-syntax/Multiple2.ts')),
             new Import('./module.js', new File('resolver/ts/import-syntax/module.js')),
             new Import('module_index', new Module('module_index', 'node_modules/module_index/index.js')),
             new Import('module_package', new Module('module_package', 'node_modules/module_package/main.js')),

--- a/test/fixtures/resolver/ts/import-syntax/Multiple2.ts
+++ b/test/fixtures/resolver/ts/import-syntax/Multiple2.ts
@@ -1,0 +1,2 @@
+export class F { }
+export class G { }

--- a/test/fixtures/resolver/ts/import-syntax/main.ts
+++ b/test/fixtures/resolver/ts/import-syntax/main.ts
@@ -4,6 +4,11 @@ import simple from './Simple';
 import { A as B } from "./Alias";
 import * as C from "./All";
 import { D, E } from "./Multiple";
+import {
+    F,
+    G
+} from
+    './Multiple2';
 import "./module.js";
 import "module_index";
 import "module_package";


### PR DESCRIPTION
Also ignored `test/Bundler/dev/104a7_dev.require.js.sources` since it contains the absolute path of the checkout.