### PR TITLE
Made ContentPipeline->push target_file optional

### DIFF
--- a/src/Bundler/Pipeline/ContentPipelineInterface.php
+++ b/src/Bundler/Pipeline/ContentPipelineInterface.php
@@ -27,12 +27,15 @@ interface ContentPipelineInterface
     public function peek(File $input_file): string;
 
     /**
-     * Push a bundled file on the pipeline with a list of dependencies.
+     * Bundles a list of dependencies into a single string.
+     *
+     * When passing a $target_file in dev mode it will take the modified time
+     * of that. It has no use otherwise.
      *
      * @param DependencyNodeInterface[] $dependencies
-     * @param File                      $target_file
-     * @param ReaderInterface           $file_reader
+     * @param ReaderInterface $file_reader
+     * @param File|null $target_file
      * @return string
      */
-    public function push(array $dependencies, File $target_file, ReaderInterface $file_reader): string;
+    public function push(array $dependencies, ReaderInterface $file_reader, File $target_file = null): string;
 }

--- a/src/Bundler/PipelineBundler.php
+++ b/src/Bundler/PipelineBundler.php
@@ -131,7 +131,7 @@ class PipelineBundler
             return;
         }
 
-        $writer->write($target, $this->pipeline->push($dependencies, $target, $reader));
+        $writer->write($target, $this->pipeline->push($dependencies, $reader, $target));
     }
 
     /**

--- a/src/EventListener/AngularHtmlListener.php
+++ b/src/EventListener/AngularHtmlListener.php
@@ -93,8 +93,8 @@ final class AngularHtmlListener
 
         return $this->pipeline->push(
             $asset->getFiles(),
-            $asset->getAssetFile($this->config->getOutputFolder(), $this->config->getSourceRoot()),
-            $reader
+            $reader,
+            $asset->getAssetFile($this->config->getOutputFolder(), $this->config->getSourceRoot())
         );
     }
 }

--- a/src/EventListener/AngularHtmlListener.php
+++ b/src/EventListener/AngularHtmlListener.php
@@ -13,6 +13,7 @@ use Hostnet\Component\Resolver\File;
 use Hostnet\Component\Resolver\FileSystem\FileReader;
 use Hostnet\Component\Resolver\FileSystem\ReaderInterface;
 use Hostnet\Component\Resolver\Import\Dependency;
+use Hostnet\Component\Resolver\Import\ImportFinderInterface;
 
 /**
  * The Angular listener checks all angular component files. If they contain a
@@ -25,11 +26,16 @@ final class AngularHtmlListener
 {
     private $config;
     private $pipeline;
+    private $finder;
 
-    public function __construct(ConfigInterface $config, ContentPipelineInterface $pipeline)
-    {
+    public function __construct(
+        ConfigInterface $config,
+        ContentPipelineInterface $pipeline,
+        ImportFinderInterface $finder
+    ) {
         $this->config   = $config;
         $this->pipeline = $pipeline;
+        $this->finder   = $finder;
     }
 
     /**
@@ -88,13 +94,12 @@ final class AngularHtmlListener
             $file_path = $owning_file->dir . '/' . $file_path;
         }
 
-        $target = new Dependency(new File(File::clean($file_path)));
-        $asset  = new Asset($target, $this->pipeline->peek($target->getFile()));
+        $target_file = new File(File::clean($file_path));
+        $asset       = new Asset($this->finder->all($target_file), $this->pipeline->peek($target_file));
 
         return $this->pipeline->push(
             $asset->getFiles(),
-            $reader,
-            $asset->getAssetFile($this->config->getOutputFolder(), $this->config->getSourceRoot())
+            $reader
         );
     }
 }

--- a/src/Packer.php
+++ b/src/Packer.php
@@ -103,7 +103,7 @@ final class Packer
             }
             $finder->addCollector($angular_collector);
 
-            $listener = new AngularHtmlListener($config, $pipeline);
+            $listener = new AngularHtmlListener($config, $pipeline, $finder);
 
             $dispatcher->addListener(AssetEvents::POST_PROCESS, [$listener, 'onPostTranspile']);
         }

--- a/test/Bundler/Pipeline/ContentPipelineTest.php
+++ b/test/Bundler/Pipeline/ContentPipelineTest.php
@@ -58,6 +58,7 @@ class ContentPipelineTest extends TestCase
     {
         $this->config->isDev()->willReturn(false);
         $this->config->getSourceRoot()->willReturn('fixtures');
+        $this->config->getCacheDir()->willReturn(__DIR__ . '/cache/new');
 
         $input_file  = new RootFile(new Module('fixtures/bar.foo', 'fixtures/bar.foo'));
         $target_file = new File('output.foo');
@@ -70,7 +71,7 @@ class ContentPipelineTest extends TestCase
 
         self::assertEquals(
             "foobar\nfoobar\n",
-            $this->content_pipeline->push([$input_file, $d1, $d2], $target_file, $reader)
+            $this->content_pipeline->push([$input_file, $d1, $d2], $reader, $target_file)
         );
     }
 
@@ -94,7 +95,7 @@ class ContentPipelineTest extends TestCase
 
         self::assertEquals(
             "foobar\nfoobar\n",
-            $this->content_pipeline->push([$input_file, $d1, $d2], $target_file, $reader)
+            $this->content_pipeline->push([$input_file, $d1, $d2], $reader, $target_file)
         );
     }
 
@@ -115,7 +116,7 @@ class ContentPipelineTest extends TestCase
 
         self::assertEquals(
             "foobar\nfoobar\n",
-            $this->content_pipeline->push([$input_file, $d1, $d2], $target_file, $reader)
+            $this->content_pipeline->push([$input_file, $d1, $d2], $reader, $target_file)
         );
     }
 
@@ -127,6 +128,7 @@ class ContentPipelineTest extends TestCase
     {
         $this->config->isDev()->willReturn(false);
         $this->config->getSourceRoot()->willReturn('fixtures');
+        $this->config->getCacheDir()->willReturn(__DIR__ . '/cache/new');
 
         $input_file  = new RootFile(new Module('fixtures/input.js', 'fixtures/input.js'));
         $target_file = new File('output.foo');
@@ -134,6 +136,6 @@ class ContentPipelineTest extends TestCase
 
         $this->content_pipeline->addProcessor(new IdentityProcessor('foo'));
 
-        self::assertEquals("foobar\nfoobar\n", $this->content_pipeline->push([$input_file], $target_file, $reader));
+        self::assertEquals("foobar\nfoobar\n", $this->content_pipeline->push([$input_file], $reader, $target_file));
     }
 }

--- a/test/Bundler/PipelineBundlerTest.php
+++ b/test/Bundler/PipelineBundlerTest.php
@@ -77,16 +77,16 @@ class PipelineBundlerTest extends TestCase
         }))->willReturn($entry_point3);
 
         $this->pipeline
-            ->push([$entry_point1], new File('dev/foo.bundle.js'), $reader->reveal())
+            ->push([$entry_point1], $reader->reveal(), new File('dev/foo.bundle.js'))
             ->willReturn('foo.js bundle');
         $this->pipeline
-            ->push([], new File('dev/foo.vendor.js'), $reader->reveal())
+            ->push([], $reader->reveal(), new File('dev/foo.vendor.js'))
             ->willReturn('foo.js vendor');
         $this->pipeline
-            ->push([$entry_point2], new File('dev/bar.js'), $reader->reveal())
+            ->push([$entry_point2], $reader->reveal(), new File('dev/bar.js'))
             ->willReturn('bar.js content');
         $this->pipeline
-            ->push([$entry_point3], new File('dev/asset.js'), $reader->reveal())
+            ->push([$entry_point3], $reader->reveal(), new File('dev/asset.js'))
             ->willReturn('asset.js content');
         $this->pipeline->peek(new File('bar.js'))->willReturn('js');
         $this->pipeline->peek(new File('asset.js'))->willReturn('js');
@@ -135,10 +135,10 @@ class PipelineBundlerTest extends TestCase
         }))->willReturn($entry_point1);
 
         $this->pipeline
-            ->push([$entry_point1], new File('dev/foobar.bundle.js'), $reader->reveal())
+            ->push([$entry_point1], $reader->reveal(), new File('dev/foobar.bundle.js'))
             ->willReturn('foobar.js bundle');
         $this->pipeline
-            ->push([], new File('dev/foobar.vendor.js'), $reader->reveal())
+            ->push([], $reader->reveal(), new File('dev/foobar.vendor.js'))
             ->willReturn('foobar.js vendor');
 
         $reader->read(Argument::that(function (File $file) {

--- a/test/EventListener/AngularHtmlListenerTest.php
+++ b/test/EventListener/AngularHtmlListenerTest.php
@@ -56,10 +56,10 @@ class AngularHtmlListenerTest extends TestCase
         $this->pipeline->peek($html)->willReturn('html');
         $this->pipeline->peek($less)->willReturn('css');
         $this->pipeline
-            ->push([new Dependency($html)], new File('dev/app.component.html'), Argument::type(FileReader::class))
+            ->push([new Dependency($html)], Argument::type(FileReader::class), new File('dev/app.component.html'))
             ->willReturn('<html>foobar</html>');
         $this->pipeline
-            ->push([new Dependency($less)], new File('dev/app.component.css'), Argument::type(FileReader::class))
+            ->push([new Dependency($less)], Argument::type(FileReader::class), new File('dev/app.component.css'))
             ->willReturn('div {color: red;}');
 
         $this->angular_html_listener->onPostTranspile(new AssetEvent($item));
@@ -83,10 +83,10 @@ class AngularHtmlListenerTest extends TestCase
         $this->pipeline->peek($html)->willReturn('html');
         $this->pipeline->peek($less)->willReturn('css');
         $this->pipeline
-            ->push([new Dependency($html)], new File('dev/test/app.component.html'), Argument::type(FileReader::class))
+            ->push([new Dependency($html)], Argument::type(FileReader::class), new File('dev/test/app.component.html'))
             ->willReturn('<html>foobar</html>');
         $this->pipeline
-            ->push([new Dependency($less)], new File('dev/test/app.component.css'), Argument::type(FileReader::class))
+            ->push([new Dependency($less)], Argument::type(FileReader::class), new File('dev/test/app.component.css'))
             ->willReturn('div {color: red;}');
 
         $this->angular_html_listener->onPostTranspile(new AssetEvent($item));

--- a/test/EventListener/AngularHtmlListenerTest.php
+++ b/test/EventListener/AngularHtmlListenerTest.php
@@ -14,6 +14,8 @@ use Hostnet\Component\Resolver\File;
 use Hostnet\Component\Resolver\FileSystem\FileReader;
 use Hostnet\Component\Resolver\FileSystem\StringReader;
 use Hostnet\Component\Resolver\Import\Dependency;
+use Hostnet\Component\Resolver\Import\ImportFinderInterface;
+use Hostnet\Component\Resolver\Import\RootFile;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 
@@ -24,6 +26,7 @@ class AngularHtmlListenerTest extends TestCase
 {
     private $config;
     private $pipeline;
+    private $finder;
 
     /**
      * @var AngularHtmlListener
@@ -34,10 +37,12 @@ class AngularHtmlListenerTest extends TestCase
     {
         $this->config   = $this->prophesize(ConfigInterface::class);
         $this->pipeline = $this->prophesize(ContentPipelineInterface::class);
+        $this->finder   = $this->prophesize(ImportFinderInterface::class);
 
         $this->angular_html_listener = new AngularHtmlListener(
             $this->config->reveal(),
-            $this->pipeline->reveal()
+            $this->pipeline->reveal(),
+            $this->finder->reveal()
         );
     }
 
@@ -50,16 +55,21 @@ class AngularHtmlListenerTest extends TestCase
         $this->config->getSourceRoot()->willReturn('');
         $this->config->getOutputFolder()->willReturn('dev');
 
-        $html = new File('app.component.html');
-        $less = new File('app.component.less');
+        $less      = new File('app.component.less');
+        $less_root = new RootFile($less);
+        $this->finder->all($less)->willReturn($less_root);
+
+        $html      = new File('app.component.html');
+        $html_root = new RootFile($html);
+        $this->finder->all($html)->willReturn($html_root);
 
         $this->pipeline->peek($html)->willReturn('html');
         $this->pipeline->peek($less)->willReturn('css');
         $this->pipeline
-            ->push([new Dependency($html)], Argument::type(FileReader::class), new File('dev/app.component.html'))
+            ->push([$html_root], Argument::type(FileReader::class))
             ->willReturn('<html>foobar</html>');
         $this->pipeline
-            ->push([new Dependency($less)], Argument::type(FileReader::class), new File('dev/app.component.css'))
+            ->push([$less_root], Argument::type(FileReader::class))
             ->willReturn('div {color: red;}');
 
         $this->angular_html_listener->onPostTranspile(new AssetEvent($item));
@@ -77,16 +87,21 @@ class AngularHtmlListenerTest extends TestCase
         $this->config->getSourceRoot()->willReturn('fixtures');
         $this->config->getOutputFolder()->willReturn('dev');
 
-        $html = new File('fixtures/test/app.component.html');
-        $less = new File('fixtures/test/app.component.less');
+        $less      = new File('fixtures/test/app.component.less');
+        $less_root = new RootFile($less);
+        $this->finder->all($less)->willReturn($less_root);
+
+        $html      = new File('fixtures/test/app.component.html');
+        $html_root = new RootFile($html);
+        $this->finder->all($html)->willReturn($html_root);
 
         $this->pipeline->peek($html)->willReturn('html');
         $this->pipeline->peek($less)->willReturn('css');
         $this->pipeline
-            ->push([new Dependency($html)], Argument::type(FileReader::class), new File('dev/test/app.component.html'))
+            ->push([$html_root], Argument::type(FileReader::class))
             ->willReturn('<html>foobar</html>');
         $this->pipeline
-            ->push([new Dependency($less)], Argument::type(FileReader::class), new File('dev/test/app.component.css'))
+            ->push([$less_root], Argument::type(FileReader::class))
             ->willReturn('div {color: red;}');
 
         $this->angular_html_listener->onPostTranspile(new AssetEvent($item));


### PR DESCRIPTION
- Made `$target_file` optional
- Swapped `$file_reader` and `$target_file` because of that
- Set default value of `$target_file` to the `$cache_file`

TODO
- Not sure what do do with `AngularHtmlListener`
- Perhaps remove argument entirely?

Feedback would be awesome :smile: