### PR TITLE
Use writer over file_put_contents, so directory will be created

### DIFF
--- a/src/Bundler/Pipeline/ContentPipeline.php
+++ b/src/Bundler/Pipeline/ContentPipeline.php
@@ -16,6 +16,7 @@ use Hostnet\Component\Resolver\Event\AssetEvents;
 use Hostnet\Component\Resolver\File;
 use Hostnet\Component\Resolver\FileSystem\ReaderInterface;
 use Hostnet\Component\Resolver\FileSystem\StringReader;
+use Hostnet\Component\Resolver\FileSystem\WriterInterface;
 use Hostnet\Component\Resolver\Import\DependencyNodeInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -30,6 +31,7 @@ final class ContentPipeline implements ContentPipelineInterface
     private $dispatcher;
     private $logger;
     private $config;
+    private $writer;
 
     /**
      * @var ContentProcessorInterface[]
@@ -39,11 +41,13 @@ final class ContentPipeline implements ContentPipelineInterface
     public function __construct(
         EventDispatcherInterface $dispatcher,
         LoggerInterface $logger,
-        ConfigInterface $config
+        ConfigInterface $config,
+        WriterInterface $writer
     ) {
         $this->dispatcher = $dispatcher;
         $this->logger     = $logger;
         $this->config     = $config;
+        $this->writer     = $writer;
         $this->processors = [];
     }
 
@@ -127,8 +131,8 @@ final class ContentPipeline implements ContentPipelineInterface
 
                 if ($this->config->isDev()) {
                     // cache the contents of the item
-                    file_put_contents(
-                        $cache_file,
+                    $this->writer->write(
+                        new File($cache_file),
                         serialize([$item->getContent(), $item->getState()->extension()])
                     );
                 }

--- a/src/Packer.php
+++ b/src/Packer.php
@@ -66,7 +66,8 @@ final class Packer
         $finder = new ImportFinder($config->cwd());
         $finder->addCollector($js_collector);
 
-        $pipeline = new ContentPipeline($dispatcher, $logger, $config);
+        $writer   = new FileWriter($config->cwd());
+        $pipeline = new ContentPipeline($dispatcher, $logger, $config, $writer);
 
         $pipeline->addProcessor(new IdentityProcessor('css'));
         $pipeline->addProcessor(new IdentityProcessor('html'));
@@ -129,7 +130,7 @@ final class Packer
             $config,
             $uglify_runner
         );
-        $bundler->execute(new FileReader($config->cwd()), new FileWriter($config->cwd()));
+        $bundler->execute(new FileReader($config->cwd()), $writer);
 
         if ($config->isDev()) {
             $cache->save();


### PR DESCRIPTION
To prevent
```
Warning: file_put_contents(<project_dir>/var/cache/dev/assets<asset_file>): failed to open stream: No such file or directory
```
when pushing an asset through the content pipeline directly.

Cause: `assets` folder was not created in this route.