### PR TITLE
Add PluginActivator, so the bundle can use the same code

### DIFF
--- a/src/Packer.php
+++ b/src/Packer.php
@@ -25,6 +25,7 @@ use Hostnet\Component\Resolver\FileSystem\FileWriter;
 use Hostnet\Component\Resolver\Import\BuiltIn\JsImportCollector;
 use Hostnet\Component\Resolver\Import\ImportFinder;
 use Hostnet\Component\Resolver\Import\Nodejs\FileResolver;
+use Hostnet\Component\Resolver\Plugin\PluginActivator;
 use Hostnet\Component\Resolver\Plugin\PluginApi;
 
 /**
@@ -65,10 +66,7 @@ final class Packer
         $pipeline->addProcessor(new JsonProcessor());
 
         $plugin_api = new PluginApi($pipeline, $finder, $config, $cache);
-
-        foreach ($config->getPlugins() as $plugin) {
-            $plugin->activate($plugin_api);
-        }
+        (new PluginActivator($plugin_api))->ensurePluginsAreActivated();
 
         $uglify_runner = new UglifyJsRunner($nodejs);
 

--- a/src/Plugin/PluginActivator.php
+++ b/src/Plugin/PluginActivator.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
+declare(strict_types=1);
+
+namespace Hostnet\Component\Resolver\Plugin;
+
+class PluginActivator
+{
+    /**
+     * @var PluginApi
+     */
+    private $plugin_api;
+
+    private $are_plugins_activated = false;
+
+    public function __construct(PluginApi $plugin_api)
+    {
+        $this->plugin_api = $plugin_api;
+    }
+
+    public function ensurePluginsAreActivated(): void
+    {
+        if ($this->are_plugins_activated) {
+            return;
+        }
+
+        foreach ($this->plugin_api->getConfig()->getPlugins() as $plugin) {
+            $plugin->activate($this->plugin_api);
+        }
+
+        $this->are_plugins_activated = true;
+    }
+}

--- a/test/Plugin/PluginActivatorTest.php
+++ b/test/Plugin/PluginActivatorTest.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
+declare(strict_types=1);
+namespace Hostnet\Component\Resolver\Plugin;
+
+use Hostnet\Component\Resolver\Config\ConfigInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Hostnet\Component\Resolver\Plugin\PluginActivator
+ */
+class PluginActivatorTest extends TestCase
+{
+    public function testEnsurePluginsAreActivated()
+    {
+        $plugin = $this->prophesize(PluginInterface::class);
+
+        $plugins = [$plugin];
+        $config  = $this->prophesize(ConfigInterface::class);
+        $config->getPlugins()->willReturn($plugins);
+
+        $plugin_api = $this->prophesize(PluginApi::class);
+        $plugin_api->getConfig()->willReturn($config);
+
+        $plugin->activate($plugin_api)->shouldBeCalledTimes(1);
+
+        $plugin_activator = new PluginActivator($plugin_api->reveal());
+        $plugin_activator->ensurePluginsAreActivated();
+        $plugin_activator->ensurePluginsAreActivated();
+    }
+}


### PR DESCRIPTION
Just found out that the plugins were not activated in the bundle yet.

This allows the packer/bundle to use the same code.