### PR TITLE
Allow trailing slash after source root

### DIFF
--- a/src/Bundler/Pipeline/ContentPipeline.php
+++ b/src/Bundler/Pipeline/ContentPipeline.php
@@ -96,7 +96,8 @@ final class ContentPipeline implements MutableContentPipelineInterface
             if (!empty($this->config->getSourceRoot())
                 && false !== strpos($module_name, $this->config->getSourceRoot())
             ) {
-                $base_dir = trim(substr($file->dir, strlen($this->config->getSourceRoot())), '/');
+                $chopped  = substr($file->dir, strlen($this->config->getSourceRoot()));
+                $base_dir = $chopped ? trim($chopped, '/') : '';
 
                 if (strlen($base_dir) > 0) {
                     $base_dir .= '/';


### PR DESCRIPTION
Otherwise the following happened
```
TypeError: trim() expects parameter 1 to be string, boolean given
```