### PR TITLE
Allow to fetch only the name of the output folder

### DIFF
--- a/src/Config/ConfigInterface.php
+++ b/src/Config/ConfigInterface.php
@@ -61,9 +61,10 @@ interface ConfigInterface
     /**
      * Return the output folder in which to dump the compiled assets.
      *
+     * @param bool $include_public_folder Whether to include the web/ directory
      * @return string
      */
-    public function getOutputFolder(): string;
+    public function getOutputFolder(bool $include_public_folder = true): string;
 
     /**
      * Return the source root folder in which the assets are located.

--- a/src/Config/FileConfig.php
+++ b/src/Config/FileConfig.php
@@ -115,13 +115,16 @@ final class FileConfig implements ConfigInterface
      *
      * @return string
      */
-    public function getOutputFolder(): string
+    public function getOutputFolder(bool $include_public_folder = true): string
     {
-        $web_root      = $this->config_file_contents['web-root'];
         $output_folder = $this->isDev()
             ? ($this->config_file_contents['output-folder-dev'] ?? 'dev')
             : ($this->config_file_contents['output-folder'] ?? 'dist');
+        if (! $include_public_folder) {
+            return $output_folder;
+        }
 
+        $web_root = $this->config_file_contents['web-root'];
         return rtrim($web_root, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $output_folder;
     }
 

--- a/test/Config/FileConfigTest.php
+++ b/test/Config/FileConfigTest.php
@@ -28,6 +28,7 @@ class FileConfigTest extends TestCase
         self::assertSame([], $config->getEntryPoints());
         self::assertSame([], $config->getAssetFiles());
         self::assertSame(self::EXPECTED_OUTPUT, $config->getOutputFolder());
+        self::assertSame('dev', $config->getOutputFolder(false));
         self::assertSame('', $config->getSourceRoot());
         self::assertSame(__DIR__ . '/../fixtures/configs/var', $config->getCacheDir());
         self::assertSame('/usr/bin/node', $config->getNodeJsExecutable()->getBinary());
@@ -55,6 +56,7 @@ class FileConfigTest extends TestCase
         self::assertSame([], $config->getEntryPoints());
         self::assertSame([], $config->getAssetFiles());
         self::assertSame(self::EXPECTED_OUTPUT, $config->getOutputFolder());
+        self::assertSame('dev', $config->getOutputFolder(false));
         self::assertSame('', $config->getSourceRoot());
         self::assertSame(__DIR__ . '/../fixtures/configs/var', $config->getCacheDir());
         self::assertSame('/usr/bin/node', $config->getNodeJsExecutable()->getBinary());
@@ -74,6 +76,7 @@ class FileConfigTest extends TestCase
         self::assertSame([], $config->getEntryPoints());
         self::assertSame([], $config->getAssetFiles());
         self::assertSame(self::EXPECTED_OUTPUT, $config->getOutputFolder());
+        self::assertSame('dev', $config->getOutputFolder(false));
         self::assertSame('', $config->getSourceRoot());
         self::assertSame(__DIR__.'/../fixtures/configs/var', $config->getCacheDir());
         self::assertSame(


### PR DESCRIPTION
Currently the twig helper includes the `web` folder in the `asset_url` function, see https://github.com/hostnet/asset-bundle/blob/master/src/Twig/AssetExtension.php#L29

That results in a style tag that doesn't work.

So needs to be possible to only get the external bit.