### PR TITLE
[WIP] New protocol at JavaScript side

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     },
     "require-dev": {
         "hostnet/phpcs-tool": "^5.2",
+        "mikey179/vfsStream": "^1.6",
         "phpunit/phpunit":    "^6.2",
         "symfony/process":    "^3.3"
     },

--- a/spec/chunk-processor.spec.js
+++ b/spec/chunk-processor.spec.js
@@ -3,60 +3,73 @@ var ChunkProcessor = require('../src/Resources/chunk-processor');
 describe("chunk-processor", function () {
     it("protocolReceiveBytes", function () {
         var chunkProcessor = new ChunkProcessor();
-        expect(chunkProcessor.protocolReceiveBytes).toEqual(7);
+        expect(chunkProcessor.numberOfBytesToAsk()).toEqual(7);
     });
 
     it("processChunk in large bits", function () {
         var chunkProcessor = new ChunkProcessor();
         // Send the header, we need 12 bytes of file contents afterwards
         var chunk = Buffer.alloc(7);
-        chunk.writeUInt32LE(12);
-        chunk.write('ABC', 4);
+        chunk.write('ABC');
+        chunk.writeUInt32LE(9, 3);
 
         var result = chunkProcessor.processChunk(chunk);
         expect(result.type).toEqual('additional-data');
-        expect(result.bytes).toEqual(12);
+        expect(result.bytes).toEqual(9);
 
-        // Send 12 bytes, part of which is the file name
-        chunk = Buffer.from("/h/foo.js\0al");
+        // Send 9 bytes, the file name
+        chunk = Buffer.from("/h/foo.js");
         result = chunkProcessor.processChunk(chunk);
         expect(result.type).toEqual('additional-data');
-        expect(result.bytes).toEqual(10);
+        expect(result.bytes).toEqual(4);
 
-        // Send the other 10 bytes of content
-        chunk = Buffer.from('ert("Hi");');
+        chunk = Buffer.alloc(4);
+        chunk.writeUInt32LE(12);
+        result = chunkProcessor.processChunk(chunk);
+        expect(result.type).toEqual('additional-data');
+        expect(result.bytes).toEqual(12);
+
+        // Send the file contents
+        chunk = Buffer.from('alert("Hi");');
         result = chunkProcessor.processChunk(chunk);
         expect(result.type).toEqual('message-received');
         expect(result.compileType).toEqual('ABC');
         expect(result.fileName).toEqual('/h/foo.js');
         expect(result.message).toEqual('alert("Hi");');
+        expect(chunkProcessor.numberOfBytesToAsk()).toEqual(7);
     });
 
     it("processChunk in small bits", function () {
         var chunkProcessor = new ChunkProcessor();
-        // Send 5 out of 7 bytes of the header, two more required
-        var chunk = Buffer.alloc(5);
-        chunk.writeUInt32LE(12);
-        chunk.write('A', 4);
 
+        // Send 2 out of 7 bytes of the header, five more required
+        var chunk = Buffer.from('AB');
         var result = chunkProcessor.processChunk(chunk);
         expect(result.type).toEqual('additional-data');
-        expect(result.bytes).toEqual(2);
+        expect(result.bytes).toEqual(5);
 
-        // Send the last two. Now 12 bytes of file content required.
-        chunk = Buffer.from('BC');
+        chunk = Buffer.alloc(5);
+        chunk.write('C');
+        chunk.writeUInt32LE(9, 1);
+
         result = chunkProcessor.processChunk(chunk);
         expect(result.type).toEqual('additional-data');
-        expect(result.bytes).toEqual(12);
+        expect(result.bytes).toEqual(9);
 
         // Send a part of the filename
         chunk = Buffer.from("/h/");
         result = chunkProcessor.processChunk(chunk);
         expect(result.type).toEqual('additional-data');
-        expect(result.bytes).toEqual(12);
+        expect(result.bytes).toEqual(6);
 
         // Send exactly the filename
-        chunk = Buffer.from("foo.js\0");
+        chunk = Buffer.from("foo.js");
+        result = chunkProcessor.processChunk(chunk);
+        expect(result.type).toEqual('additional-data');
+        expect(result.bytes).toEqual(4);
+
+        chunk = Buffer.alloc(4);
+        chunk.writeUInt32LE(12);
         result = chunkProcessor.processChunk(chunk);
         expect(result.type).toEqual('additional-data');
         expect(result.bytes).toEqual(12);
@@ -74,5 +87,73 @@ describe("chunk-processor", function () {
         expect(result.compileType).toEqual('ABC');
         expect(result.fileName).toEqual('/h/foo.js');
         expect(result.message).toEqual('alert("Hi");');
+    });
+
+    it("processChunk with empty file", function () {
+        var chunkProcessor = new ChunkProcessor();
+
+        var chunk = Buffer.alloc(7);
+        chunk.write('ABC');
+        chunk.writeUInt32LE(0, 3);
+
+        var result = chunkProcessor.processChunk(chunk);
+        expect(result.type).toEqual('additional-data');
+        expect(result.bytes).toEqual(4);
+
+        // Ok, so now we are asked for the file length
+        // Let's also send 0 for that
+        chunk = Buffer.alloc(4);
+        chunk.writeUInt32LE(0);
+
+        result = chunkProcessor.processChunk(chunk);
+        expect(result.type).toEqual('message-received');
+        expect(result.compileType).toEqual('ABC');
+        expect(result.fileName).toEqual('');
+        expect(result.message).toEqual('');
+    });
+
+    it("processChunk send all at once", function () {
+        var chunkProcessor = new ChunkProcessor();
+
+        var chunk = Buffer.alloc(32);
+        chunk.write("ABC");
+        chunk.writeUInt32LE(9, 3);
+        chunk.write("/h/foo.js", 7);
+        chunk.writeUInt32LE(12, 16);
+        chunk.write("alert(\"Hi\");", 20);
+
+        var result = chunkProcessor.processChunk(chunk);
+
+        expect(result.type).toEqual('message-received');
+        expect(result.compileType).toEqual('ABC');
+        expect(result.fileName).toEqual('/h/foo.js');
+        expect(result.message).toEqual('alert("Hi");');
+    });
+
+    it("processChunk handles two messages", function () {
+        var chunkProcessor = new ChunkProcessor();
+
+        var chunk = Buffer.alloc(32);
+        chunk.write("ABC");
+        chunk.writeUInt32LE(9, 3);
+        chunk.write("/h/foo.js", 7);
+        chunk.writeUInt32LE(12, 16);
+        chunk.write("alert(\"Hi\");", 20);
+
+        var result = chunkProcessor.processChunk(chunk);
+
+        expect(result.type).toEqual('message-received');
+        expect(result.compileType).toEqual('ABC');
+        expect(result.fileName).toEqual('/h/foo.js');
+        expect(result.message).toEqual('alert("Hi");');
+
+        chunk.write("/h/bar.js", 7);
+        chunk.write("alert(\"Yo\");", 20);
+        result = chunkProcessor.processChunk(chunk);
+
+        expect(result.type).toEqual('message-received');
+        expect(result.compileType).toEqual('ABC');
+        expect(result.fileName).toEqual('/h/bar.js');
+        expect(result.message).toEqual('alert("Yo");');
     });
 });

--- a/spec/reply-sender.spec.js
+++ b/spec/reply-sender.spec.js
@@ -9,8 +9,8 @@ describe("chunk-processor", function () {
         expect(sent.length).toEqual(2);
 
         expect(sent[0].constructor.name).toEqual('Buffer');
-        expect(sent[0].readUInt32LE()).toEqual(9);
-        expect(sent[0].readUInt8(4)).toEqual(3);
+        expect(sent[0].readUInt8()).toEqual(3);
+        expect(sent[0].readUInt32LE(1)).toEqual(9);
 
         expect(sent[1]).toEqual('ABCDE𒍅');
     });

--- a/src/Bundler/Runner/UnixSocket.php
+++ b/src/Bundler/Runner/UnixSocket.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
+declare(strict_types=1);
+
+namespace Hostnet\Component\Resolver\Bundler\Runner;
+
+use Hostnet\Component\Resolver\Bundler\Runner\Exception\SocketException;
+
+/**
+ * Small abstraction around the socket functions of php
+ *
+ * It adds
+ * - type hints
+ * - exceptions on failures (instead of return false)
+ * - and the ability to unit-test a socket using class
+ */
+class UnixSocket
+{
+    private $socket;
+
+    public function __construct()
+    {
+        $this->socket = socket_create(AF_UNIX, SOCK_STREAM, 0);
+    }
+
+    public function connect(string $address): void
+    {
+        if (! @socket_connect($this->socket, $address)) {
+            throw new SocketException('Problem connecting to the socket');
+        }
+    }
+
+    public function send(string $to_send, int $bytes): void
+    {
+        if (! @socket_send($this->socket, $to_send, $bytes, 0)) {
+            throw new SocketException('Problem sending to the socket');
+        }
+    }
+
+    public function receive(int $bytes): string
+    {
+        $buffer = '';
+        if (false === @socket_recv($this->socket, $buffer, $bytes, MSG_WAITALL)) {
+            throw new SocketException('Problem receiving from the socket');
+        }
+
+        return $buffer;
+    }
+
+    public function close(): void
+    {
+        socket_close($this->socket);
+    }
+}

--- a/src/Bundler/Runner/UnixSocketFactory.php
+++ b/src/Bundler/Runner/UnixSocketFactory.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
+declare(strict_types=1);
+
+namespace Hostnet\Component\Resolver\Bundler\Runner;
+
+/**
+ * Factory that creates unix sockets.
+ *
+ * Created so the creation of a unix socket can differ in a unit-test.
+ */
+class UnixSocketFactory
+{
+    public function make(): UnixSocket
+    {
+        return new UnixSocket();
+    }
+}

--- a/src/Config/FileConfig.php
+++ b/src/Config/FileConfig.php
@@ -8,6 +8,7 @@ namespace Hostnet\Component\Resolver\Config;
 
 use Hostnet\Component\Resolver\Bundler\Runner\RunnerInterface;
 use Hostnet\Component\Resolver\Bundler\Runner\SingleProcessRunner;
+use Hostnet\Component\Resolver\Bundler\Runner\UnixSocketFactory;
 use Hostnet\Component\Resolver\Bundler\Runner\UnixSocketRunner;
 use Hostnet\Component\Resolver\File;
 use Hostnet\Component\Resolver\Import\Nodejs\Executable;
@@ -207,7 +208,7 @@ final class FileConfig implements ConfigInterface
     public function getRunner(): RunnerInterface
     {
         if ($this->config_file_contents['enable-unix-socket'] ?? false) {
-            return new UnixSocketRunner($this);
+            return new UnixSocketRunner($this, new UnixSocketFactory());
         }
 
         return new SingleProcessRunner($this);

--- a/src/Resources/build.js
+++ b/src/Resources/build.js
@@ -32,7 +32,7 @@ unixServer = net.createServer(function (client) {
 
     client.on('readable', function() {
 
-        var chunk, bytes = chunkProcessor.protocolReceiveBytes;
+        var chunk, bytes = chunkProcessor.numberOfBytesToAsk();
 
         while (null !== (chunk = client.read(Math.min(1024, bytes)))) {
             var request = chunkProcessor.processChunk(chunk);
@@ -42,7 +42,7 @@ unixServer = net.createServer(function (client) {
                     break;
 
                 case "message-received":
-                    bytes = chunkProcessor.protocolReceiveBytes;
+                    bytes = chunkProcessor.numberOfBytesToAsk();
                     try {
                         sendReply(true, processor.process(request.compileType, request.fileName, request.message));
                     } catch (e) {

--- a/src/Resources/reply-sender.js
+++ b/src/Resources/reply-sender.js
@@ -5,17 +5,16 @@
                 reply = Buffer.alloc(5),
                 flags = 0;
 
-            reply.writeUInt32LE(messageReplyLength);
-
             if (isSuccessful) {
+
                 flags |= 1;
             }
-
             if (stopProcess) {
+
                 flags |= 2;
             }
-
-            reply.writeUInt8(flags, 4);
+            reply.writeUInt8(flags);
+            reply.writeUInt32LE(messageReplyLength, 1);
 
             client.write(reply, function () {});
             client.write(message, callback);

--- a/test/Bundler/Runner/UnixSocketFactoryTest.php
+++ b/test/Bundler/Runner/UnixSocketFactoryTest.php
@@ -15,6 +15,10 @@ class UnixSocketFactoryTest extends TestCase
     public function testMake()
     {
         $factory = new UnixSocketFactory();
+
+        if (! function_exists('socket_create')) {
+            self::markTestSkipped('Not available without socket extension');
+        }
         self::assertInstanceOf(UnixSocket::class, $factory->make());
     }
 }

--- a/test/Bundler/Runner/UnixSocketFactoryTest.php
+++ b/test/Bundler/Runner/UnixSocketFactoryTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
+declare(strict_types=1);
+namespace Hostnet\Component\Resolver\Bundler\Runner;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Hostnet\Component\Resolver\Bundler\Runner\UnixSocketFactory
+ */
+class UnixSocketFactoryTest extends TestCase
+{
+    public function testMake()
+    {
+        $factory = new UnixSocketFactory();
+        self::assertInstanceOf(UnixSocket::class, $factory->make());
+    }
+}

--- a/test/Bundler/Runner/UnixSocketRunnerTest.php
+++ b/test/Bundler/Runner/UnixSocketRunnerTest.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
+declare(strict_types=1);
+namespace Hostnet\Component\Resolver\Bundler\Runner;
+
+use Hostnet\Component\Resolver\Bundler\ContentItem;
+use Hostnet\Component\Resolver\Config\ConfigInterface;
+use Hostnet\Component\Resolver\File;
+use Hostnet\Component\Resolver\FileSystem\ReaderInterface;
+use Hostnet\Component\Resolver\Import\Nodejs\Executable;
+use org\bovigo\vfs\vfsStream;
+use org\bovigo\vfs\vfsStreamFile;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Hostnet\Component\Resolver\Bundler\Runner\UnixSocketRunner
+ */
+class UnixSocketRunnerTest extends TestCase
+{
+    private $cache;
+    private $config;
+    private $factory;
+    private $socket;
+
+    /**
+     * @var UnixSocketRunner
+     */
+    private $unix_socket_runner;
+
+    protected function setUp()
+    {
+        // Fake a cache directory with a socket file in it
+        // So the program does not try to start the build process
+        $this->cache = vfsStream::setup('unixSocketCacheDir');
+        $this->cache->addChild(new vfsStreamFile('asset-lib.socket'));
+
+        $this->config = $this->prophesize(ConfigInterface::class);
+        $this->config->getCacheDir()->willReturn(vfsStream::url('unixSocketCacheDir'));
+        $this->config->getProjectRoot()->willReturn('/dir');
+        $this->config->getNodeJsExecutable()->willReturn(new Executable('echo', 'node_modules'));
+        $this->socket  = $this->prophesize(UnixSocket::class);
+        $this->factory = $this->prophesize(UnixSocketFactory::class);
+        $this->factory->make()->willReturn($this->socket);
+
+        $this->unix_socket_runner = new UnixSocketRunner(
+            $this->config->reveal(),
+            $this->factory->reveal()
+        );
+    }
+
+    public function testExecuteTypeTooLong()
+    {
+        $file   = new File('a.js');
+        $reader = $this->prophesize(ReaderInterface::class);
+        $reader->read($file)->willReturn('awesome content');
+        $item = new ContentItem($file, 'a', $reader->reveal());
+
+        $this->expectException(\DomainException::class);
+        $this->unix_socket_runner->execute('NASA', $item);
+    }
+
+    public function testExecute()
+    {
+        $file   = new File('a.js');
+        $reader = $this->prophesize(ReaderInterface::class);
+        $reader->read($file)->willReturn('awesome content');
+        $item = new ContentItem($file, 'a', $reader->reveal());
+
+        $this->setUpProtocol(true, 'awesome response');
+
+        self::assertSame(
+            'awesome response',
+            $this->unix_socket_runner->execute('UGL', $item)
+        );
+    }
+
+    public function testExecuteFailed()
+    {
+        $file   = new File('a.js');
+        $reader = $this->prophesize(ReaderInterface::class);
+        $reader->read($file)->willReturn('awesome content');
+        $item = new ContentItem($file, 'a', $reader->reveal());
+
+        $this->setUpProtocol(false, 'error response');
+
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage('error response');
+
+        $this->unix_socket_runner->execute('UGL', $item);
+    }
+
+    private function setUpProtocol(bool $success, string $message)
+    {
+        $url = vfsStream::url('unixSocketCacheDir') . '/asset-lib.socket';
+        $this->socket->connect($url)->will(function () use ($success, $message) {
+            $file     = '/dir/a.js';
+            $content  = 'awesome content';
+            $expected =
+                'UGL' .
+                pack('V', strlen($file)) .
+                $file .
+                pack('V', strlen($content)) .
+                $content;
+
+            $this->send($expected, strlen($expected))->will(function () use ($success, $message) {
+                $this->receive(1)->will(function () use ($success, $message) {
+                    $this->receive(4)->will(function () use ($message) {
+                        $this->receive(16)->will(function () use ($message) {
+                            $this->close()->shouldBeCalled();
+                            return $message;
+                        });
+                        return pack('V', 16);
+                    });
+                    return $success ? 1 : 0;
+                });
+            });
+        });
+    }
+}

--- a/test/Bundler/Runner/UnixSocketTest.php
+++ b/test/Bundler/Runner/UnixSocketTest.php
@@ -20,6 +20,9 @@ class UnixSocketTest extends TestCase
 
     protected function setUp()
     {
+        if (! function_exists('socket_create')) {
+            self::markTestSkipped('Not available without socket extension');
+        }
         $this->unix_socket = new UnixSocket();
     }
 

--- a/test/Bundler/Runner/UnixSocketTest.php
+++ b/test/Bundler/Runner/UnixSocketTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
+declare(strict_types=1);
+namespace Hostnet\Component\Resolver\Bundler\Runner;
+
+use Hostnet\Component\Resolver\Bundler\Runner\Exception\SocketException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Hostnet\Component\Resolver\Bundler\Runner\UnixSocket
+ */
+class UnixSocketTest extends TestCase
+{
+    /**
+     * @var UnixSocket
+     */
+    private $unix_socket;
+
+    protected function setUp()
+    {
+        $this->unix_socket = new UnixSocket();
+    }
+
+    public function testConnect()
+    {
+        $this->expectException(SocketException::class);
+        $this->unix_socket->connect('bla');
+    }
+
+    public function testSend()
+    {
+        $this->expectException(SocketException::class);
+        $this->unix_socket->send('bla', 3);
+    }
+
+    public function testReceive()
+    {
+        $this->expectException(SocketException::class);
+        $this->unix_socket->receive(1);
+    }
+
+    public function testClose()
+    {
+        $this->unix_socket->close();
+        self::assertTrue(true);
+    }
+}


### PR DESCRIPTION
Currently there is a problem when sending empty files to the `UnixSocketRunner`. The JavaScript side will wait for more bytes to be sent, while the php side will be waiting for the response.

This PR means
- a new protocol that sends the length of the file name separately (see protocol below)
- the `ChunkProcessor` is now written like a state machine.
- the `ChunkProcessor` can handle it if you send more bytes than asked (i.e. you can send a whole message in one go)
- a lot more test cases for `ChunkProcessor`

Do **not** merge though, PHP side is not yet included!

Current protocol for the unix socket:
- file length (32 bit, little endian byte order)
- type (3 bytes)
- file name (keep reading bytes till `\0` character)
- file (file length bytes)

New protocol
- type (3 bytes)
- file name length (32 bit, little endian byte order)
- file name (file name length bytes)
- file length (32 bit, little endian byte order)
- file (file length bytes)

Interested in feedback on protocol / JS side :)