### PR TITLE
Receiving 0 bytes returns false

### DIFF
--- a/src/Bundler/Runner/UnixSocket.php
+++ b/src/Bundler/Runner/UnixSocket.php
@@ -41,6 +41,10 @@ class UnixSocket
 
     public function receive(int $bytes): string
     {
+        if ($bytes === 0) {
+            return '';
+        }
+
         $buffer = '';
         if (false === @socket_recv($this->socket, $buffer, $bytes, MSG_WAITALL)) {
             throw new SocketException('Problem receiving from the socket');

--- a/test/Bundler/Runner/UnixSocketTest.php
+++ b/test/Bundler/Runner/UnixSocketTest.php
@@ -44,6 +44,11 @@ class UnixSocketTest extends TestCase
         $this->unix_socket->receive(1);
     }
 
+    public function testReceiveZeroBytes()
+    {
+        self::assertSame('', $this->unix_socket->receive(0));
+    }
+
     public function testClose()
     {
         $this->unix_socket->close();


### PR DESCRIPTION
Executing
```php
socket_recv($this->socket, $buffer, 0, MSG_WAITALL);
```
returns `false`

Was expecting an empty string in that case.