### PR TITLE
Ignore SIGHUP instead of using nohup

### DIFF
--- a/src/Bundler/Runner/UnixSocketRunner.php
+++ b/src/Bundler/Runner/UnixSocketRunner.php
@@ -158,7 +158,7 @@ class UnixSocketRunner implements RunnerInterface
 
         $node_js = $this->config->getNodeJsExecutable();
         $cmd     = sprintf(
-            'nohup %s %s %s < /dev/null > %s 2>&1 &',
+            '%s %s %s < /dev/null > %s 2>&1 &',
             escapeshellarg($node_js->getBinary()),
             escapeshellarg(implode(DIRECTORY_SEPARATOR, [__DIR__, '..', '..', 'Resources', 'build.js'])),
             escapeshellarg($this->socket_location),

--- a/src/Resources/build.js
+++ b/src/Resources/build.js
@@ -11,6 +11,12 @@ process.umask(0o000);
 var numberOfRequestsHandled = 0,
     unixServer;
 
+// SIGHUP ("signal hang up") is a signal sent to a process when its controlling
+// terminal is closed.
+// We ignore this signal, so we can continue running as a background process
+process.on('SIGHUP', function () {
+});
+
 unixServer = net.createServer(function (client) {
 
     var chunkProcessor = new ChunkProcessor();


### PR DESCRIPTION
Using `nohup` works on linux, but crashes on macs with this error:
```
nohup: can't detach from console: Inappropriate ioctl for device
```
Opting to ignore the `SIGHUP` signal instead.