### PR TITLE
Support libraries that are already initialized

### DIFF
--- a/spec/require.spec.js
+++ b/spec/require.spec.js
@@ -62,6 +62,14 @@ describe("Require.js module register method test", function () {
         expect(lib.require('foo')).toEqual('FOO');
     });
 
+    it("with AMD define object", function() {
+        lib.register("foo-static", function (define, require, module, exports) {
+            define([], {foo: 1});
+        });
+
+        expect(lib.require('foo-static')).toEqual({foo: 1});
+    });
+
     it("with AMD define and reserved requirements", function() {
         lib.register("amd_define/foo", function (define, require, module, exports) {
             define([], function () {

--- a/src/Resources/require.js
+++ b/src/Resources/require.js
@@ -77,7 +77,7 @@
                     // define(["dep1", "dep2"], function (dep_1, dep_2) {})
 
                     dependencies = a;
-                    initializer = b;
+                    initializer = typeof b === 'function' ? b : function () { return b; };
                 }
             } else {
                 // define("foo", ["dep1", "dep2"], function (dep_1, dep_2) {})


### PR DESCRIPTION
Originally a part of #27 by @pjordaan 

In order to reduce the size of the original pull request.