### PR TITLE
Protect against odd characters in module name

### DIFF
--- a/src/Bundler/Processor/ModuleProcessor.php
+++ b/src/Bundler/Processor/ModuleProcessor.php
@@ -26,9 +26,11 @@ final class ModuleProcessor implements ContentProcessorInterface
 
     public function transpile(string $cwd, ContentItem $item): void
     {
-        $js  = "register('" . $item->module_name . "', function (define, require, module, exports) {\n";
-        $js .= $item->getContent();
-        $js .= "\n});\n";
+        $js = "register("
+            . json_encode($item->module_name, JSON_UNESCAPED_SLASHES)
+            . ", function (define, require, module, exports) {\n"
+            . $item->getContent()
+            . "\n});\n";
 
         $item->transition(ContentState::READY, $js);
     }

--- a/test/Bundler/Processor/ModuleProcessorTest.php
+++ b/test/Bundler/Processor/ModuleProcessorTest.php
@@ -47,12 +47,16 @@ class ModuleProcessorTest extends TestCase
 
     public function testTranspile()
     {
-        $item = new ContentItem(new File(basename(__FILE__)), 'foobar.js', new StringReader('console.log("foobar");'));
+        $item = new ContentItem(
+            new File(basename(__FILE__)),
+            'bar/a"/\'/foobar.js',
+            new StringReader('console.log("foobar");')
+        );
 
         $this->module_processor->transpile(__DIR__, $item);
 
         self::assertStringEqualsFile(__DIR__ . '/expected.module.js', $item->getContent());
-        self::assertSame('foobar.js', $item->module_name);
+        self::assertSame('bar/a"/\'/foobar.js', $item->module_name);
         self::assertSame(ContentState::READY, $item->getState()->current());
     }
 }

--- a/test/Bundler/Processor/expected.module.js
+++ b/test/Bundler/Processor/expected.module.js
@@ -1,3 +1,3 @@
-register('foobar.js', function (define, require, module, exports) {
+register("bar/a\"/'/foobar.js", function (define, require, module, exports) {
 console.log("foobar");
 });


### PR DESCRIPTION
Perhaps doubtful that a module name will contain these characters, but it won't crash should a module name contain this.

Gotten from #27 by @pjordaan 