### PR TITLE
Ignore .d.ts entirely

### DIFF
--- a/src/Import/BuiltIn/TsImportCollector.php
+++ b/src/Import/BuiltIn/TsImportCollector.php
@@ -47,15 +47,7 @@ final class TsImportCollector implements ImportCollectorInterface
             $path = $matches[2][$i];
 
             try {
-                $import    = $this->nodejs_resolver->asRequire($path, $file);
-                $base_name = basename($import->getImportedFile()->path);
-
-                $ext = substr($base_name, strpos($base_name, '.'));
-
-                if ($ext === '.d.ts') {
-                    continue;
-                }
-
+                $import = $this->nodejs_resolver->asRequire($path, $file);
                 $imports->addImport($import);
             } catch (\RuntimeException $e) {
                 continue;

--- a/src/Plugin/TsPlugin.php
+++ b/src/Plugin/TsPlugin.php
@@ -24,7 +24,7 @@ final class TsPlugin implements PluginInterface
             new JsImportCollector(
                 new FileResolver($plugin_api->getConfig(), ['.ts', '.js', '.json', '.node'])
             ),
-            new FileResolver($plugin_api->getConfig(), ['.ts', '.d.ts', '.js', '.json', '.node'])
+            new FileResolver($plugin_api->getConfig(), ['.ts', '.js', '.json', '.node'])
         );
         if ($plugin_api->getConfig()->isDev()) {
             $ts_collector = new CachedImportCollector($ts_collector, $plugin_api->getCache());

--- a/test/Import/BuiltIn/TsImportCollectorTest.php
+++ b/test/Import/BuiltIn/TsImportCollectorTest.php
@@ -33,7 +33,7 @@ class TsImportCollectorTest extends TestCase
 
         $this->ts_import_collector = new TsImportCollector(
             new JsImportCollector(new FileResolver($config->reveal(), ['.ts', '.js', '.json', '.node'])),
-            new FileResolver($config->reveal(), ['.ts', '.d.ts', '.js', '.json', '.node'])
+            new FileResolver($config->reveal(), ['.ts', '.js', '.json', '.node'])
         );
     }
 


### PR DESCRIPTION
From #27 via @pjordaan 

Currently some imports fail. They end up at the definition file, while a source file is available too.

For example /animations resolved to node_modules//animations/index.d.ts, while it should resolve to node_modules//bundles/platform-browser-animations.umd.js by reading the package.json.