### PR TITLE
Only strip .ts from module name

### DIFF
--- a/src/Bundler/Processor/TsContentProcessor.php
+++ b/src/Bundler/Processor/TsContentProcessor.php
@@ -34,11 +34,7 @@ final class TsContentProcessor implements ContentProcessorInterface
 
     public function transpile(string $cwd, ContentItem $item): void
     {
-        $module_name = $item->module_name;
-
-        if (false !== ($i = strrpos($module_name, '.'))) {
-            $module_name = substr($module_name, 0, $i);
-        }
+        $module_name = preg_replace('/\.ts$/i', '', $item->module_name);
 
         $item->transition(
             ContentState::PROCESSED,

--- a/test/Bundler/Processor/TsContentProcessorTest.php
+++ b/test/Bundler/Processor/TsContentProcessorTest.php
@@ -53,16 +53,27 @@ class TsContentProcessorTest extends TestCase
         self::assertSame(ContentState::PROCESSED, $state->current());
     }
 
-    public function testTranspile()
+    /**
+     * @dataProvider transpileProvider
+     */
+    public function testTranspile(string $original_name, string $expected_name)
     {
-        $item = new ContentItem(new File(basename(__FILE__)), 'foobar.ts', new FileReader(__DIR__));
+        $item = new ContentItem(new File(basename(__FILE__)), $original_name, new FileReader(__DIR__));
 
         $this->ts_runner->execute(RunnerType::TYPE_SCRIPT, $item)->willReturn('ts code');
 
         $this->ts_content_processor->transpile(__DIR__, $item);
 
         self::assertContains('ts code', $item->getContent());
-        self::assertSame('foobar', $item->module_name);
+        self::assertSame($expected_name, $item->module_name);
         self::assertSame(ContentState::PROCESSED, $item->getState()->current());
+    }
+
+    public function transpileProvider()
+    {
+        return [
+            ['foobar.ts', 'foobar'],
+            ['ks-swiper.module', 'ks-swiper.module']
+        ];
     }
 }


### PR DESCRIPTION
Via #27 from @pjordaan 

Do not automatically remove . from a module name, it's not always '.ts'