### PR TITLE
Added phpunit bridge to see deprecations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ cache:
 
 matrix:
   include:
-    # PHP tests
+    # PHP 7.1 tests
     - language: php
       php: 7.1
       env: COMPOSER_FLAGS="--prefer-lowest"
@@ -33,6 +33,20 @@ matrix:
       script: vendor/bin/phpunit
     - language: php
       php: 7.1
+      env: SYMFONY_VERSION="4.0.*"
+      before_script:
+        - composer update $COMPOSER_FLAGS --prefer-dist
+      script: vendor/bin/phpunit
+
+    # PHP 7.2 tests
+    - language: php
+      php: 7.2
+      env: COMPOSER_FLAGS=""
+      before_script:
+        - composer update $COMPOSER_FLAGS --prefer-dist
+      script: vendor/bin/phpunit
+    - language: php
+      php: 7.2
       env: SYMFONY_VERSION="4.0.*"
       before_script:
         - composer update $COMPOSER_FLAGS --prefer-dist

--- a/composer.json
+++ b/composer.json
@@ -11,10 +11,11 @@
         "symfony/event-dispatcher": "^4.0|^3.3"
     },
     "require-dev": {
-        "hostnet/phpcs-tool": "^5.2",
-        "mikey179/vfsStream": "^1.6",
-        "phpunit/phpunit":    "^6.2",
-        "symfony/process":    "^4.0|^3.3"
+        "hostnet/phpcs-tool":     "^5.2",
+        "mikey179/vfsStream":     "^1.6",
+        "phpunit/phpunit":        "^6.2",
+        "symfony/phpunit-bridge": "^4.0",
+        "symfony/process":        "^4.0|^3.3"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,4 +11,8 @@
             <directory>./src</directory>
         </whitelist>
     </filter>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
 </phpunit>

--- a/src/Bundler/Runner/SingleProcessRunner.php
+++ b/src/Bundler/Runner/SingleProcessRunner.php
@@ -52,6 +52,7 @@ class SingleProcessRunner implements RunnerInterface
             File::makeAbsolutePath($item->file->path, $this->config->getProjectRoot())
         );
         $process = new Process($cmd, null, ['NODE_PATH' => $node_js->getNodeModulesLocation()], $item->getContent());
+        $process->inheritEnvironmentVariables();
 
         $process->run();
 


### PR DESCRIPTION
Previous result with the bridge:

```
PHPUnit 6.4.4 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.1.11-1+ubuntu14.04.1+deb.sury.org+1
Configuration: /home/ydelange/projects/libs/asset-lib/phpunit.xml.dist

Testing 
...............................................................  63 / 137 ( 45%)
............................................................... 126 / 137 ( 91%)
...........                                                     137 / 137 (100%)

Time: 415 ms, Memory: 10.00MB

OK (137 tests, 348 assertions)

Remaining deprecation notices (6)

Not inheriting environment variables is deprecated since Symfony 3.3 and will always happen in 4.0. Set "Process::inheritEnvironmentVariables()" to true instead: 6x
    5x in SingleProcessRunnerTest::testExecute from Hostnet\Component\Resolver\Bundler\Runner
    1x in SingleProcessRunnerTest::testUnsuccessfulProcess from Hostnet\Component\Resolver\Bundler\Runner
```