### PR TITLE
moved excluded list to the splitting strategy class

### DIFF
--- a/src/Config/ConfigInterface.php
+++ b/src/Config/ConfigInterface.php
@@ -62,13 +62,6 @@ interface ConfigInterface
     public function getAssetFiles(): array;
 
     /**
-     * Return a list of files to exclude when bundling. These are the files defined under 'excludes'.
-     *
-     * @return string[]
-     */
-    public function getExcludedFiles(): array;
-
-    /**
      * Returns a list of plugins.
      *
      * @return PluginInterface[]

--- a/src/Config/SimpleConfig.php
+++ b/src/Config/SimpleConfig.php
@@ -26,7 +26,6 @@ final class SimpleConfig implements ConfigInterface
     private $include_paths;
     private $entry_points;
     private $asset_files;
-    private $excluded_files;
     private $web_root;
     private $output_folder;
     private $source_root;
@@ -46,7 +45,6 @@ final class SimpleConfig implements ConfigInterface
         array $include_paths,
         array $entry_points,
         array $asset_files,
-        array $excluded_files,
         string $web_root,
         string $output_folder,
         string $source_root,
@@ -64,7 +62,6 @@ final class SimpleConfig implements ConfigInterface
         $this->include_paths  = $include_paths;
         $this->entry_points   = $entry_points;
         $this->asset_files    = $asset_files;
-        $this->excluded_files = $excluded_files;
         $this->web_root       = $web_root;
         $this->output_folder  = $output_folder;
         $this->source_root    = $source_root;
@@ -122,14 +119,6 @@ final class SimpleConfig implements ConfigInterface
     public function getAssetFiles(): array
     {
         return $this->asset_files;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getExcludedFiles(): array
-    {
-        return $this->excluded_files;
     }
 
     /**

--- a/src/Split/OneOnOneSplittingStrategy.php
+++ b/src/Split/OneOnOneSplittingStrategy.php
@@ -8,12 +8,20 @@ namespace Hostnet\Component\Resolver\Split;
 use Hostnet\Component\Resolver\Import\DependencyNodeInterface;
 
 /**
- * Resolves chunks to always be added.
+ * Resolves chunks to always be added, unless on the exclusion list.
  */
-class OneOnOneSplittingStrategy implements EntryPointSplittingStrategyInterface
+final class OneOnOneSplittingStrategy implements EntryPointSplittingStrategyInterface
 {
+    private $exclude_list;
+
+    public function __construct(array $exclude_list = [])
+    {
+        $this->exclude_list = array_combine($exclude_list, $exclude_list);
+    }
+
     public function resolveChunk(string $entry_point, DependencyNodeInterface $dependency): ?string
     {
-        return $entry_point;
+        $dep = $dependency->getFile()->path;
+        return isset($this->exclude_list[$dep]) ? null : $entry_point;
     }
 }

--- a/test/Bundler/PipelineBundlerTest.php
+++ b/test/Bundler/PipelineBundlerTest.php
@@ -69,7 +69,6 @@ class PipelineBundlerTest extends TestCase
         $this->config->getProjectRoot()->willReturn(__DIR__);
         $this->config->getEntryPoints()->willReturn(['foo.js']);
         $this->config->getAssetFiles()->willReturn(['bar.js']);
-        $this->config->getExcludedFiles()->willReturn([]);
         $this->config->getEventDispatcher()->willReturn($event_dispatcher);
         $this->config->getReporter()->willReturn(new NullReporter());
         $this->config->getSplitStrategy()->willReturn(new OneOnOneSplittingStrategy());
@@ -142,7 +141,6 @@ class PipelineBundlerTest extends TestCase
         $this->config->getProjectRoot()->willReturn(__DIR__);
         $this->config->getEntryPoints()->willReturn(['foobar.js']);
         $this->config->getAssetFiles()->willReturn([]);
-        $this->config->getExcludedFiles()->willReturn([]);
         $this->config->getEventDispatcher()->willReturn($event_dispatcher);
         $this->config->getReporter()->willReturn(new NullReporter());
         $this->config->getSplitStrategy()->willReturn(new OneOnOneSplittingStrategy());
@@ -188,10 +186,9 @@ class PipelineBundlerTest extends TestCase
         $this->config->getProjectRoot()->willReturn(__DIR__);
         $this->config->getEntryPoints()->willReturn(['foo.js']);
         $this->config->getAssetFiles()->willReturn([]);
-        $this->config->getExcludedFiles()->willReturn(['bar.js']);
         $this->config->getEventDispatcher()->willReturn($event_dispatcher);
         $this->config->getReporter()->willReturn(new NullReporter());
-        $this->config->getSplitStrategy()->willReturn(new OneOnOneSplittingStrategy());
+        $this->config->getSplitStrategy()->willReturn(new OneOnOneSplittingStrategy(['bar.js']));
 
         $bar          = new RootFile(new File('bar.js'));
         $baz          = new RootFile(new File('baz.js'));

--- a/test/Config/SimpleConfigTest.php
+++ b/test/Config/SimpleConfigTest.php
@@ -33,7 +33,6 @@ class SimpleConfigTest extends TestCase
             ['phpunit'],
             ['foo'],
             ['bar'],
-            ['baz'],
             'web',
             'phpunit',
             'src',
@@ -48,7 +47,6 @@ class SimpleConfigTest extends TestCase
         self::assertEquals(['phpunit'], $config->getIncludePaths());
         self::assertEquals(['foo'], $config->getEntryPoints());
         self::assertEquals(['bar'], $config->getAssetFiles());
-        self::assertEquals(['baz'], $config->getExcludedFiles());
         self::assertEquals('web' . DIRECTORY_SEPARATOR . 'phpunit', $config->getOutputFolder());
         self::assertEquals('phpunit', $config->getOutputFolder(false));
         self::assertEquals('src', $config->getSourceRoot());
@@ -74,7 +72,6 @@ class SimpleConfigTest extends TestCase
             ['phpunit'],
             ['foo'],
             ['bar'],
-            ['baz'],
             'web',
             'phpunit',
             'src',
@@ -89,7 +86,6 @@ class SimpleConfigTest extends TestCase
         self::assertEquals(['phpunit'], $config->getIncludePaths());
         self::assertEquals(['foo'], $config->getEntryPoints());
         self::assertEquals(['bar'], $config->getAssetFiles());
-        self::assertEquals(['baz'], $config->getExcludedFiles());
         self::assertEquals('web' . DIRECTORY_SEPARATOR . 'phpunit', $config->getOutputFolder());
         self::assertEquals('phpunit', $config->getOutputFolder(false));
         self::assertEquals('src', $config->getSourceRoot());
@@ -110,7 +106,6 @@ class SimpleConfigTest extends TestCase
             ['phpunit'],
             ['foo'],
             ['bar'],
-            ['baz'],
             'web',
             'phpunit',
             'src',

--- a/test/Split/OneOnOneSplittingStrategyTest.php
+++ b/test/Split/OneOnOneSplittingStrategyTest.php
@@ -16,9 +16,17 @@ class OneOnOneSplittingStrategyTest extends TestCase
 {
     public function testResolveChunk()
     {
-        $one_on_one_splitting_strategy = new OneOnOneSplittingStrategy();
+        $one_on_one_splitting_strategy                = new OneOnOneSplittingStrategy();
+        $one_on_one_splitting_strategy_with_exclusion = new OneOnOneSplittingStrategy(['/dev/hda1']);
 
-        $dep = new Dependency(new File('/dev/hda1'));
-        self::assertEquals('/dev/null', $one_on_one_splitting_strategy->resolveChunk('/dev/null', $dep));
+        $dep1 = new Dependency(new File('/dev/hda1'));
+        $dep2 = new Dependency(new File('/home/user/.bashrc'));
+        self::assertEquals('/dev/null', $one_on_one_splitting_strategy->resolveChunk('/dev/null', $dep1));
+        self::assertEquals('/dev/null', $one_on_one_splitting_strategy->resolveChunk('/dev/null', $dep2));
+        self::assertEquals(null, $one_on_one_splitting_strategy_with_exclusion->resolveChunk('/dev/null', $dep1));
+        self::assertEquals(
+            '/dev/null',
+            $one_on_one_splitting_strategy_with_exclusion->resolveChunk('/dev/null', $dep2)
+        );
     }
 }


### PR DESCRIPTION
This moves the exclusion list to the splitting strategy class. A side effect is that dependencies of dependencies are also no longer excluded, but this functionality was actually broken as it always excluded these and was not making the assumption another dependency could also require that dependency.