### PR TITLE
leave out source root in OneOneSplittingStrategy

### DIFF
--- a/src/Split/OneOnOneSplittingStrategy.php
+++ b/src/Split/OneOnOneSplittingStrategy.php
@@ -12,16 +12,21 @@ use Hostnet\Component\Resolver\Import\DependencyNodeInterface;
  */
 final class OneOnOneSplittingStrategy implements EntryPointSplittingStrategyInterface
 {
+    private $source_root;
+
     private $exclude_list;
 
-    public function __construct(array $exclude_list = [])
+    public function __construct(string $source_root = '', array $exclude_list = [])
     {
+        $this->source_root  = '#^' . preg_quote($source_root, '#') . '#';
         $this->exclude_list = array_combine($exclude_list, $exclude_list);
     }
 
     public function resolveChunk(string $entry_point, DependencyNodeInterface $dependency): ?string
     {
-        $dep = $dependency->getFile()->path;
-        return isset($this->exclude_list[$dep]) ? null : $entry_point;
+        $dep = preg_replace($this->source_root, '', $dependency->getFile()->path);
+        return isset($this->exclude_list[$dep])
+            ? null
+            : ltrim(preg_replace($this->source_root, '', $entry_point), '/\\\\');
     }
 }

--- a/test/Bundler/PipelineBundlerTest.php
+++ b/test/Bundler/PipelineBundlerTest.php
@@ -188,7 +188,7 @@ class PipelineBundlerTest extends TestCase
         $this->config->getAssetFiles()->willReturn([]);
         $this->config->getEventDispatcher()->willReturn($event_dispatcher);
         $this->config->getReporter()->willReturn(new NullReporter());
-        $this->config->getSplitStrategy()->willReturn(new OneOnOneSplittingStrategy(['bar.js']));
+        $this->config->getSplitStrategy()->willReturn(new OneOnOneSplittingStrategy('', ['bar.js']));
 
         $bar          = new RootFile(new File('bar.js'));
         $baz          = new RootFile(new File('baz.js'));

--- a/test/Split/OneOnOneSplittingStrategyTest.php
+++ b/test/Split/OneOnOneSplittingStrategyTest.php
@@ -17,16 +17,19 @@ class OneOnOneSplittingStrategyTest extends TestCase
     public function testResolveChunk()
     {
         $one_on_one_splitting_strategy                = new OneOnOneSplittingStrategy();
-        $one_on_one_splitting_strategy_with_exclusion = new OneOnOneSplittingStrategy(['/dev/hda1']);
+        $one_on_one_splitting_strategy_with_exclusion = new OneOnOneSplittingStrategy('', ['/dev/hda1']);
+        $one_on_one_splitting_strategy_with_source    = new OneOnOneSplittingStrategy('/dev/', ['hda1']);
 
         $dep1 = new Dependency(new File('/dev/hda1'));
         $dep2 = new Dependency(new File('/home/user/.bashrc'));
-        self::assertEquals('/dev/null', $one_on_one_splitting_strategy->resolveChunk('/dev/null', $dep1));
-        self::assertEquals('/dev/null', $one_on_one_splitting_strategy->resolveChunk('/dev/null', $dep2));
+        self::assertEquals('dev/null', $one_on_one_splitting_strategy->resolveChunk('/dev/null', $dep1));
+        self::assertEquals('dev/null', $one_on_one_splitting_strategy->resolveChunk('/dev/null', $dep2));
         self::assertEquals(null, $one_on_one_splitting_strategy_with_exclusion->resolveChunk('/dev/null', $dep1));
         self::assertEquals(
-            '/dev/null',
+            'dev/null',
             $one_on_one_splitting_strategy_with_exclusion->resolveChunk('/dev/null', $dep2)
         );
+        self::assertEquals(null, $one_on_one_splitting_strategy_with_source->resolveChunk('/dev/null', $dep1));
+        self::assertEquals('null', $one_on_one_splitting_strategy_with_source->resolveChunk('/dev/null', $dep2));
     }
 }


### PR DESCRIPTION
found out with the functional test in asset-bundle. The output file names were prefixed with the source root.