### PR TITLE
Fixed issue with entry point having a different extension than .js

### DIFF
--- a/src/Bundler/EntryPoint.php
+++ b/src/Bundler/EntryPoint.php
@@ -35,7 +35,12 @@ final class EntryPoint
                 $this->asset_files[] = $dependency;
                 return true;
             }
-            $result = $split_strategy->resolveChunk($file->getFile()->path, $dependency);
+
+            // Make sure to have a .js extension.
+            $file_obj    = $file->getFile();
+            $output_file = File::clean($file_obj->dir . '/' . $file_obj->getBaseName() . '.js');
+
+            $result = $split_strategy->resolveChunk($output_file, $dependency);
             if (!$result) {
                 return false;
             }

--- a/test/Bundler/EntryPointTest.php
+++ b/test/Bundler/EntryPointTest.php
@@ -61,4 +61,25 @@ class EntryPointTest extends TestCase
             )
         );
     }
+
+    public function testWithDifferentExtension()
+    {
+        $file = new File('app.ts');
+        $dep  = new Dependency($file);
+
+        $resolve_strategy = new class implements EntryPointSplittingStrategyInterface {
+            public function resolveChunk(string $entry_point, DependencyNodeInterface $dependency): ?string
+            {
+                return $entry_point;
+            }
+        };
+
+        $entry_point = new EntryPoint($dep, $resolve_strategy);
+
+        self::assertEquals($file, $entry_point->getFile());
+        self::assertSame(
+            ['output/app.js' => [$dep]],
+            $entry_point->getFilesToBuild('output')
+        );
+    }
 }


### PR DESCRIPTION
In some cases entry points are not JS file but will eventually resolve to JS files. This change is to make sure the extension is always `.js`.