### PR TITLE
Fixed issue with files starting with a dot

### DIFF
--- a/src/Bundler/Asset.php
+++ b/src/Bundler/Asset.php
@@ -78,6 +78,8 @@ final class Asset
             $base_dir .= '/';
         }
 
-        return new File($output_folder . '/' . $base_dir . $this->file->getBaseName() . '.' . $this->extension);
+        $ext = empty($this->extension) ? '' : ('.' . $this->extension);
+
+        return new File($output_folder . '/' . $base_dir . $this->file->getBaseName() . $ext);
     }
 }

--- a/src/File.php
+++ b/src/File.php
@@ -19,7 +19,7 @@ class File
     {
         $this->path      = $path;
         $this->dir       = dirname($path);
-        $this->extension = pathinfo($path, PATHINFO_EXTENSION);
+        $this->extension = basename($this->path)[0] === '.' ? '' : pathinfo($path, PATHINFO_EXTENSION);
     }
 
     /**

--- a/src/File.php
+++ b/src/File.php
@@ -19,7 +19,9 @@ class File
     {
         $this->path      = $path;
         $this->dir       = dirname($path);
-        $this->extension = basename($this->path)[0] === '.' ? '' : pathinfo($path, PATHINFO_EXTENSION);
+        $this->extension = basename($path)[0] === '.' && false === strpos($path, '.', 1)
+            ? ''
+            : pathinfo($path, PATHINFO_EXTENSION);
     }
 
     /**

--- a/src/Plugin/CorePlugin.php
+++ b/src/Plugin/CorePlugin.php
@@ -47,6 +47,7 @@ final class CorePlugin implements PluginInterface
 
         $plugin_api->addProcessor(new IdentityProcessor('css'));
         $plugin_api->addProcessor(new IdentityProcessor('html'));
+        $plugin_api->addProcessor(new IdentityProcessor(''));
 
         if ($config->getSocketType() === UnixSocketType::PRE_PROCESS) {
             $ensure_closed_listener = new EnsureRunnerClosedListener($plugin_api->getRunner());

--- a/test/Bundler/AssetTest.php
+++ b/test/Bundler/AssetTest.php
@@ -50,4 +50,14 @@ class AssetTest extends TestCase
 
         self::assertSame('foo/bar/file.css', $asset->getAssetFile('foo/bar', '')->path);
     }
+
+    public function testWithoutExtension()
+    {
+        $file = new File('.test');
+        $dep  = new Dependency($file);
+
+        $asset = new Asset($dep, '');
+
+        self::assertSame('foo/bar/.test', $asset->getAssetFile('foo/bar', '')->path);
+    }
 }

--- a/test/Bundler/AssetTest.php
+++ b/test/Bundler/AssetTest.php
@@ -53,11 +53,13 @@ class AssetTest extends TestCase
 
     public function testWithoutExtension()
     {
-        $file = new File('.test');
-        $dep  = new Dependency($file);
-
-        $asset = new Asset($dep, '');
-
-        self::assertSame('foo/bar/.test', $asset->getAssetFile('foo/bar', '')->path);
+        self::assertSame(
+            'foo/bar/.test',
+            (new Asset(new Dependency(new File('.test')), ''))->getAssetFile('foo/bar', '')->path
+        );
+        self::assertSame(
+            'foo/bar/.foo.bar',
+            (new Asset(new Dependency(new File('.foo.bar')), 'bar'))->getAssetFile('foo/bar', '')->path
+        );
     }
 }

--- a/test/FileTest.php
+++ b/test/FileTest.php
@@ -39,5 +39,17 @@ class FileTest extends TestCase
             File::clean(__DIR__ . '/../some/other/path'),
             File::makeAbsolutePath('../some/other/path', __DIR__)
         );
+
+        $file2 = new File('.htaccess');
+        self::assertEquals('.', $file2->dir);
+        self::assertEquals('', $file2->extension);
+        self::assertEquals('.htaccess', $file2->getName());
+        self::assertEquals('.htaccess', $file2->getBaseName());
+
+        $file3 = new File('.foo.bar');
+        self::assertEquals('.', $file3->dir);
+        self::assertEquals('', $file3->extension);
+        self::assertEquals('.foo.bar', $file3->getName());
+        self::assertEquals('.foo.bar', $file3->getBaseName());
     }
 }

--- a/test/FileTest.php
+++ b/test/FileTest.php
@@ -48,8 +48,8 @@ class FileTest extends TestCase
 
         $file3 = new File('.foo.bar');
         self::assertEquals('.', $file3->dir);
-        self::assertEquals('', $file3->extension);
+        self::assertEquals('bar', $file3->extension);
         self::assertEquals('.foo.bar', $file3->getName());
-        self::assertEquals('.foo.bar', $file3->getBaseName());
+        self::assertEquals('.foo', $file3->getBaseName());
     }
 }


### PR DESCRIPTION
This solves the oddly created files for .htaccess and such. I also added a processor which can 'handle' these files. Since they have no extension, they are treated as-is files.