### PR TITLE
gzip plugin added

### DIFF
--- a/src/Plugin/GzipPlugin.php
+++ b/src/Plugin/GzipPlugin.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
+declare(strict_types=1);
+namespace Hostnet\Component\Resolver\Plugin;
+
+use Hostnet\Component\Resolver\Event\FileEvent;
+use Hostnet\Component\Resolver\Event\FileEvents;
+use Hostnet\Component\Resolver\File;
+use Hostnet\Component\Resolver\FileSystem\FileWriter;
+
+/**
+ * This plugin outputs a gzipped file next to the output file. Enabling this with the correct web server settings
+ * will serve a static gzipped file if the browser accepts gzip encoding.
+ * For example in Apache this can be done with a simple .htaccess file.
+ */
+class GzipPlugin implements PluginInterface
+{
+    public function activate(PluginApi $plugin_api): void
+    {
+        $config     = $plugin_api->getConfig();
+        $dispatcher = $config->getEventDispatcher();
+        $dispatcher->addListener(FileEvents::POST_WRITE, function (FileEvent $ev) use ($config, $dispatcher) {
+            $content      = $ev->getContent();
+            $gzip_content = gzencode($content, 9);
+            if (strlen($gzip_content) < strlen($content)) {
+                $writer = new FileWriter($dispatcher, $config->getProjectRoot());
+                $writer->write(new File($ev->getFile()->path . '.gz'), $gzip_content);
+            }
+        });
+    }
+}

--- a/test/Plugin/GzipPluginTest.php
+++ b/test/Plugin/GzipPluginTest.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * @copyright 2018 Hostnet B.V.
+ */
+declare(strict_types=1);
+namespace Hostnet\Component\Resolver\Plugin;
+
+use Hostnet\Component\Resolver\Config\ConfigInterface;
+use Hostnet\Component\Resolver\Event\FileEvent;
+use Hostnet\Component\Resolver\Event\FileEvents;
+use Hostnet\Component\Resolver\File;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+/**
+ * @covers \Hostnet\Component\Resolver\Plugin\GzipPlugin
+ */
+class GzipPluginTest extends TestCase
+{
+    public function testActivate()
+    {
+        $plugin = new GzipPlugin();
+
+        $dispatcher = new EventDispatcher();
+
+        $config = $this->prophesize(ConfigInterface::class);
+        $config->getEventDispatcher()->willReturn($dispatcher);
+        $config->getProjectRoot()->willReturn('');
+
+        $api = $this->prophesize(PluginApi::class);
+        $api->getConfig()->willReturn($config->reveal());
+
+        $plugin->activate($api->reveal());
+
+        $file = sys_get_temp_dir() . DIRECTORY_SEPARATOR . uniqid();
+
+        try {
+            $contents = str_repeat('file contents', 5);
+
+            $event = new FileEvent(new File($file), $contents);
+
+            $dispatcher->dispatch(FileEvents::POST_WRITE, $event);
+
+            self::assertTrue(file_exists($file . '.gz'));
+            self::assertEquals($contents, gzdecode(file_get_contents($file . '.gz')));
+        } finally {
+            @unlink($file);
+            @unlink($file . '.gz');
+        }
+    }
+
+    public function testActivateNoGzipImprovement()
+    {
+        $plugin = new GzipPlugin();
+
+        $dispatcher = new EventDispatcher();
+
+        $config = $this->prophesize(ConfigInterface::class);
+        $config->getEventDispatcher()->willReturn($dispatcher);
+
+        $api = $this->prophesize(PluginApi::class);
+        $api->getConfig()->willReturn($config->reveal());
+
+        $plugin->activate($api->reveal());
+
+        $file = sys_get_temp_dir() . DIRECTORY_SEPARATOR . uniqid();
+
+        try {
+            $event = new FileEvent(new File($file), '');
+
+            $dispatcher->dispatch(FileEvents::POST_WRITE, $event);
+
+            self::assertFalse(file_exists($file . '.gz'));
+        } finally {
+            @unlink($file);
+            @unlink($file . '.gz');
+        }
+    }
+}


### PR DESCRIPTION
outputs another file with .gz output that contains a gzipped variation of the file. In combination with proper settings in Apache you can provide the gzipped variation without having to zip it on the fly per request