### PR TITLE
Fixed issue where inline files where not being detected as changed

### DIFF
--- a/src/Bundler/Pipeline/ContentPipeline.php
+++ b/src/Bundler/Pipeline/ContentPipeline.php
@@ -209,8 +209,8 @@ final class ContentPipeline implements MutableContentPipelineInterface
         $files = [];
 
         // Collect all inline dependencies, since if any of those changed we need to recompile.
-        $walker = new TreeWalker(function (DependencyNodeInterface $d) use (&$files) {
-            if (!$d->isInlineDependency()) {
+        $walker = new TreeWalker(function (DependencyNodeInterface $d) use ($dependency, &$files) {
+            if ($d !== $dependency && !$d->isInlineDependency()) {
                 return false;
             }
 


### PR DESCRIPTION
Fixed issue where inline files where not being detected as changed. This was due to a recent change where the root of the dependency tree was also processed by the walker.