### PR TITLE
Fixed issue with files in folders starting with a dot

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -17,9 +17,11 @@ class File
 
     public function __construct(string $path)
     {
+        $file_name = basename($path);
+
         $this->path      = $path;
         $this->dir       = dirname($path);
-        $this->extension = basename($path)[0] === '.' && false === strpos($path, '.', 1)
+        $this->extension = $file_name[0] === '.' && false === strpos($file_name, '.', 1)
             ? ''
             : pathinfo($path, PATHINFO_EXTENSION);
     }

--- a/test/FileTest.php
+++ b/test/FileTest.php
@@ -51,5 +51,11 @@ class FileTest extends TestCase
         self::assertEquals('bar', $file3->extension);
         self::assertEquals('.foo.bar', $file3->getName());
         self::assertEquals('.foo', $file3->getBaseName());
+
+        $file4 = new File('app/Resources/assets/.htaccess');
+        self::assertEquals('app/Resources/assets', $file4->dir);
+        self::assertEquals('', $file4->extension);
+        self::assertEquals('app/Resources/assets/.htaccess', $file4->getName());
+        self::assertEquals('.htaccess', $file4->getBaseName());
     }
 }


### PR DESCRIPTION
The previous fix was not complete enough, it wrongfully checked the full path if it started with a dot instead of the filename. This should fix that.