### PR TITLE
single process runner supports Brotli too

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "brotli": "1.3.2",
     "clean-css": "^4.1.9",
     "less": "^2.7.0",
+    "split": "^1.0.1",
     "typescript": "^2.5.0",
     "uglify-js": "^3.1.0"
   },

--- a/src/Bundler/Runner/SingleProcessRunner.php
+++ b/src/Bundler/Runner/SingleProcessRunner.php
@@ -28,7 +28,8 @@ class SingleProcessRunner implements RunnerInterface
         RunnerType::CLEAN_CSS => 'cleancss.js',
         RunnerType::LESS => 'lessc.js',
         RunnerType::TYPE_SCRIPT => 'tsc.js',
-        RunnerType::UGLIFY => 'uglify.js'
+        RunnerType::UGLIFY => 'uglify.js',
+        RunnerType::BROTLI => 'brotli.js'
     ];
 
     public function __construct(ConfigInterface $config, array $files = [])

--- a/src/Bundler/Runner/js/brotli.js
+++ b/src/Bundler/Runner/js/brotli.js
@@ -3,7 +3,7 @@ var processor = require("../../../Resources/processor");
 
 function compile(source) {
     var fileName = path.resolve(process.argv[2]);
-    process.stdout.write(processor.process(processor.CLE, fileName, source));
+    process.stdout.write(processor.process(processor.BRO, fileName, source));
 }
 
 require('./stream-stdin')(compile);

--- a/src/Bundler/Runner/js/lessc.js
+++ b/src/Bundler/Runner/js/lessc.js
@@ -6,11 +6,4 @@ function compile(source) {
     process.stdout.write(processor.process(processor.LES, fileName, source));
 }
 
-var content = '';
-
-process.stdin.resume();
-process.stdin.on('data', function(buf) { content += buf.toString(); });
-process.stdin.on('end', function() {
-    // your code here
-    compile(content);
-});
+require('./stream-stdin')(compile);

--- a/src/Bundler/Runner/js/stream-stdin.js
+++ b/src/Bundler/Runner/js/stream-stdin.js
@@ -1,0 +1,16 @@
+/**
+ * Streams stdin properly and calls the compiled method with the resulted content afterwards
+ */
+module.exports = function streamFunction(compile) {
+    var content = '';
+
+    // we need to split it on newlines so unicode characters can not be split in 2 data events.
+    var stream = process.stdin.pipe(require('split')());
+    stream.on('data', function (buf) {
+        content += buf.toString() + '\n';
+    });
+    stream.on('end', function () {
+        // your code here
+        compile(content);
+    });
+};

--- a/src/Bundler/Runner/js/tsc.js
+++ b/src/Bundler/Runner/js/tsc.js
@@ -6,11 +6,4 @@ function compile(source) {
     process.stdout.write(processor.process(processor.TSC, fileName, source));
 }
 
-var content = '';
-
-process.stdin.resume();
-process.stdin.on('data', function(buf) { content += buf.toString(); });
-process.stdin.on('end', function() {
-    // your code here
-    compile(content);
-});
+require('./stream-stdin')(compile);

--- a/src/Bundler/Runner/js/uglify.js
+++ b/src/Bundler/Runner/js/uglify.js
@@ -5,12 +5,4 @@ function compile(source) {
     var fileName = path.resolve(process.argv[2]);
     process.stdout.write(processor.process(processor.UGL, fileName, source));
 }
-
-var content = '';
-
-process.stdin.resume();
-process.stdin.on('data', function(buf) { content += buf.toString(); });
-process.stdin.on('end', function() {
-    // your code here
-    compile(content);
-});
+require('./stream-stdin')(compile);


### PR DESCRIPTION
I also ran into the issue that the on('data') event split a unicode character was split in 2 binary characters which failed uglify.js into minifying the code.... Moved the stdin reading to a more generic solution.