### PR TITLE
make the import collectors a bit more reusable

### DIFF
--- a/src/Import/BuiltIn/JsImportCollector.php
+++ b/src/Import/BuiltIn/JsImportCollector.php
@@ -18,9 +18,12 @@ final class JsImportCollector implements ImportCollectorInterface
 {
     private $nodejs_resolver;
 
-    public function __construct(FileResolverInterface $nodejs_resolver)
+    private $extensions;
+
+    public function __construct(FileResolverInterface $nodejs_resolver, array $extensions = ['js'])
     {
         $this->nodejs_resolver = $nodejs_resolver;
+        $this->extensions      = $extensions;
     }
 
     /**
@@ -28,7 +31,7 @@ final class JsImportCollector implements ImportCollectorInterface
      */
     public function supports(File $file): bool
     {
-        return $file->extension === 'js';
+        return in_array($file->extension, $this->extensions, true);
     }
 
     /**

--- a/src/Import/BuiltIn/TsImportCollector.php
+++ b/src/Import/BuiltIn/TsImportCollector.php
@@ -18,11 +18,16 @@ final class TsImportCollector implements ImportCollectorInterface
 {
     private $js_import_collector;
     private $nodejs_resolver;
+    private $extensions;
 
-    public function __construct(JsImportCollector $js_import_collector, FileResolverInterface $nodejs_resolver)
-    {
+    public function __construct(
+        JsImportCollector $js_import_collector,
+        FileResolverInterface $nodejs_resolver,
+        array $extensions = ['ts']
+    ) {
         $this->js_import_collector = $js_import_collector;
         $this->nodejs_resolver     = $nodejs_resolver;
+        $this->extensions          = $extensions;
     }
 
     /**
@@ -30,7 +35,7 @@ final class TsImportCollector implements ImportCollectorInterface
      */
     public function supports(File $file): bool
     {
-        return $file->extension === 'ts';
+        return in_array($file->extension, $this->extensions, true);
     }
 
     /**

--- a/test/Import/BuiltIn/JsImportCollectorTest.php
+++ b/test/Import/BuiltIn/JsImportCollectorTest.php
@@ -32,7 +32,8 @@ class JsImportCollectorTest extends TestCase
         $config->getIncludePaths()->willReturn([]);
 
         $this->js_import_collector = new JsImportCollector(
-            new FileResolver($config->reveal(), ['.js', '.json', '.node'])
+            new FileResolver($config->reveal(), ['.js', '.json', '.node']),
+            ['js', 'jsx']
         );
     }
 
@@ -50,7 +51,7 @@ class JsImportCollectorTest extends TestCase
             [false, new File('foo')],
             [false, new File('foo.ts')],
             [false, new File('foo.less')],
-            [false, new File('foo.jsx')],
+            [true, new File('foo.jsx')],
             [true, new File('foo.js')],
         ];
     }

--- a/test/Import/BuiltIn/TsImportCollectorTest.php
+++ b/test/Import/BuiltIn/TsImportCollectorTest.php
@@ -33,7 +33,8 @@ class TsImportCollectorTest extends TestCase
 
         $this->ts_import_collector = new TsImportCollector(
             new JsImportCollector(new FileResolver($config->reveal(), ['.ts', '.js', '.json', '.node'])),
-            new FileResolver($config->reveal(), ['.ts', '.js', '.json', '.node'])
+            new FileResolver($config->reveal(), ['.ts', '.js', '.json', '.node']),
+            ['js', 'ts']
         );
     }
 
@@ -49,7 +50,7 @@ class TsImportCollectorTest extends TestCase
     {
         return [
             [false, new File('foo')],
-            [false, new File('foo.js')],
+            [true, new File('foo.js')],
             [false, new File('foo.less')],
             [false, new File('foo.jsx')],
             [true, new File('foo.ts')],


### PR DESCRIPTION
The main problem stays that the import collectors make no sense and are forced to work only on typescript or javascript. Typescript is a superset of javascript and the imports in Typescript are just plain ES6. Still ES6 needs to be transpiled to ES5 code for generic browser stuff, but the forced extension check on ts files for TsImportCollector makes very little sense.