### PR TITLE
Do not override require/define methods if alreay defined

### DIFF
--- a/src/Resources/require.js
+++ b/src/Resources/require.js
@@ -1,4 +1,8 @@
 (function (window) {
+    if (typeof window.require === 'function') {
+        return;
+    }
+
     var _modules = {};
 
     // Exceptions


### PR DESCRIPTION
I'm having a really hard time testing this (so that is why there is no test for it), so suggestions are appriciated.

Anyhow, this should prevent any overriding of the `window.require` in case you are loading from two different sources.