### PR TITLE
Performance improvements

### DIFF
--- a/src/Cache/CachedImportCollector.php
+++ b/src/Cache/CachedImportCollector.php
@@ -22,8 +22,8 @@ final class CachedImportCollector implements ImportCollectorInterface
 
     public function __construct(ImportCollectorInterface $inner, CacheInterface $cache)
     {
-        $this->inner = $inner;
-        $this->cache = $cache;
+        $this->inner      = $inner;
+        $this->cache      = $cache;
         $this->file_cache = new \SplObjectStorage();
     }
 

--- a/src/File.php
+++ b/src/File.php
@@ -20,7 +20,7 @@ class File
         $file_name = basename($path);
 
         $this->path      = $path;
-        $this->dir       = dirname($path);
+        $this->dir       = \dirname($path);
         $this->extension = $file_name[0] === '.' && false === strpos($file_name, '.', 1)
             ? ''
             : pathinfo($path, PATHINFO_EXTENSION);
@@ -66,6 +66,10 @@ class File
      */
     public static function clean(string $path): string
     {
+        if (false === \strpos($path, './') && false === \strpos($path, '.\\')) {
+            return $path;
+        }
+
         $parts = explode('/', str_replace(['\\', '//'], '/', $path));
 
         $absolutes = [];

--- a/src/File.php
+++ b/src/File.php
@@ -66,11 +66,13 @@ class File
      */
     public static function clean(string $path): string
     {
-        if (false === \strpos($path, './') && false === \strpos($path, '.\\')) {
+        $path = str_replace(['\\', '//'], '/', $path);
+
+        if (false === \strpos($path, './')) {
             return $path;
         }
 
-        $parts = explode('/', str_replace(['\\', '//'], '/', $path));
+        $parts = explode('/', $path);
 
         $absolutes = [];
         foreach ($parts as $part) {

--- a/src/Import/BuiltIn/AngularImportCollector.php
+++ b/src/Import/BuiltIn/AngularImportCollector.php
@@ -21,7 +21,7 @@ final class AngularImportCollector implements ImportCollectorInterface
      */
     public function supports(File $file): bool
     {
-        return $file->extension === 'ts' && '.component.ts' === substr($file->path, -13);
+        return $file->extension === 'ts' && \strlen($file->path) - 13 === strrpos($file->path, '.component.ts');
     }
 
     /**

--- a/src/Import/BuiltIn/JsImportCollector.php
+++ b/src/Import/BuiltIn/JsImportCollector.php
@@ -31,7 +31,12 @@ final class JsImportCollector implements ImportCollectorInterface
      */
     public function supports(File $file): bool
     {
-        return in_array($file->extension, $this->extensions, true);
+        foreach ($this->extensions as $extension) {
+            if ($file->extension === $extension) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/src/Import/BuiltIn/TsImportCollector.php
+++ b/src/Import/BuiltIn/TsImportCollector.php
@@ -35,7 +35,12 @@ final class TsImportCollector implements ImportCollectorInterface
      */
     public function supports(File $file): bool
     {
-        return in_array($file->extension, $this->extensions, true);
+        foreach ($this->extensions as $extension) {
+            if ($file->extension === $extension) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/src/Import/Import.php
+++ b/src/Import/Import.php
@@ -12,9 +12,9 @@ use Hostnet\Component\Resolver\File;
  */
 final class Import
 {
-    private $as;
-    private $import;
-    private $virtual;
+    public $as;
+    public $import;
+    public $virtual;
 
     public function __construct(string $as, File $import, bool $virtual = false)
     {

--- a/src/Import/ImportCollection.php
+++ b/src/Import/ImportCollection.php
@@ -59,7 +59,11 @@ final class ImportCollection
      */
     public function extends(ImportCollection $imports): void
     {
-        $this->imports   = array_merge($this->imports, $imports->getImports());
-        $this->resources = array_merge($this->resources, $imports->getResources());
+        foreach ($imports->imports as $import) {
+            $this->imports[] = $import;
+        }
+        foreach ($imports->resources as $resource) {
+            $this->resources[] = $resource;
+        }
     }
 }

--- a/src/Import/ImportFinder.php
+++ b/src/Import/ImportFinder.php
@@ -63,7 +63,7 @@ final class ImportFinder implements MutableImportFinderInterface
 
             foreach ($imports->getResources() as $import) {
                 if (!isset($seen[$import->path])) {
-                    $queue[] = [$import, $dep[0], false, true];
+                    $queue[]             = [$import, $dep[0], false, true];
                     $seen[$import->path] = true;
                 }
             }

--- a/src/Import/ImportFinder.php
+++ b/src/Import/ImportFinder.php
@@ -41,26 +41,30 @@ final class ImportFinder implements MutableImportFinderInterface
         $files = [];
         $queue = $this->get($file);
 
-        $seen = array_values(array_map(function (array $d) {
+        $seen = array_combine(array_values(array_map(function (array $d) {
             return $d[0]->path;
-        }, $queue));
+        }, $queue)), array_fill(0, \count($queue), true));
 
-        while (count($queue) > 0) {
+        while (\count($queue) > 0) {
             $dep     = array_shift($queue);
             $files[] = $dep;
 
             $imports = $this->findImports($dep[0]);
 
             foreach ($imports->getImports() as $import) {
-                if (!in_array($import->getImportedFile()->path, $seen, true)) {
-                    $queue[] = [$import->getImportedFile(), $dep[0], $import->isVirtual(), false];
-                    $seen[]  = $import->getImportedFile()->path;
+                $imported_file = $import->import;
+
+                if (!isset($seen[$imported_file->path])) {
+                    $queue[] = [$imported_file, $dep[0], $import->virtual, false];
+
+                    $seen[$imported_file->path] = true;
                 }
             }
+
             foreach ($imports->getResources() as $import) {
-                if (!in_array($import->path, $seen, true)) {
+                if (!isset($seen[$import->path])) {
                     $queue[] = [$import, $dep[0], false, true];
-                    $seen[]  = $import->path;
+                    $seen[$import->path] = true;
                 }
             }
         }
@@ -78,7 +82,7 @@ final class ImportFinder implements MutableImportFinderInterface
         $results = [];
 
         foreach ($imports->getImports() as $import) {
-            $results[$import->getAs()] = [$import->getImportedFile(), $file, $import->isVirtual(), false];
+            $results[$import->as] = [$import->import, $file, $import->virtual, false];
         }
         foreach ($imports->getResources() as $import) {
             $results[$import->path] = [$import, $file, false, true];


### PR DESCRIPTION
Some xdebug profiling revealed the following:
- `CachedImportCollector::collect` was be being called multiple times for the same file. Simply caching the result in memory already gave a quick boost.
- `File::clean` was quite expensive, and in most cases (for already absolute paths) it didn't really do anything. It only does something when the path contains `./` or `.\`.
- `AngularImportCollector::supports` the `substr` is slower than doing a `strrpos`.
- in some cases `in_array` is slower than doing a `foreach`
- `ImportFinder::all` using the array keys as lookup instead of the array values is a lot faster
- public access to properties is faster than calling a method, so the `Import` also has public properties.