### PR TITLE
Added Font rewrite plugin to also provider the fonts in a css file

### DIFF
--- a/spec/steps/css_rewrite.spec.js
+++ b/spec/steps/css_rewrite.spec.js
@@ -1,0 +1,63 @@
+let builder = require('../../src/Builder/js/build');
+
+describe("css_rewrite.js", function () {
+    let step = require('../../src/Builder/js/steps/css_rewrite');
+
+    it('execute', function () {
+        let content = Buffer.from(
+            "body{ background: red;} @font-face {font-family: myFirstFont; src: url('sansation_light.woff');}"
+        );
+        let result = step(new builder.File('foo.css', 'foo.css', content), {paths: {out: '/foo/bar/', root: '/foo/'}});
+
+        expect(result.name).toBe('foo.css');
+        expect(result.module).toBe('foo.css');
+
+        expect(result.additionalFiles.length).toBe(1);
+        expect(result.additionalFiles[0].outputFile).toBe('/foo/bar/fonts/sansation_light.woff');
+        expect(result.additionalFiles[0].inputFiles.length).toBe(1);
+
+        expect(result.additionalFiles[0].inputFiles[0].path).toBe('/foo/sansation_light.woff');
+        expect(result.additionalFiles[0].inputFiles[0].extension).toBe('.woff');
+        expect(result.additionalFiles[0].inputFiles[0].needsRebuild).toBe(true);
+        expect(result.additionalFiles[0].inputFiles[0].skipFileSteps).toBe(false);
+
+        expect(result.content.toString()).toBe(
+            'body{ background: red;} @font-face {font-family: myFirstFont; src: url("fonts/sansation_light.woff");}'
+        );
+    });
+
+    it('execute double quotes', function () {
+        let content = Buffer.from(
+            "body{ background: red;} @font-face {font-family: myFirstFont; src: url(\"sansation_light.woff\");}"
+        );
+        let result = step(new builder.File('foo.css', 'foo.css', content), {paths: {out: '/foo/bar/', root: '/foo/'}});
+
+        expect(result.name).toBe('foo.css');
+        expect(result.module).toBe('foo.css');
+
+        expect(result.additionalFiles.length).toBe(1);
+        expect(result.additionalFiles[0].outputFile).toBe('/foo/bar/fonts/sansation_light.woff');
+        expect(result.additionalFiles[0].inputFiles.length).toBe(1);
+
+        expect(result.additionalFiles[0].inputFiles[0].path).toBe('/foo/sansation_light.woff');
+        expect(result.additionalFiles[0].inputFiles[0].extension).toBe('.woff');
+        expect(result.additionalFiles[0].inputFiles[0].needsRebuild).toBe(true);
+        expect(result.additionalFiles[0].inputFiles[0].skipFileSteps).toBe(false);
+
+        expect(result.content.toString()).toBe(
+            'body{ background: red;} @font-face {font-family: myFirstFont; src: url("fonts/sansation_light.woff");}'
+        );
+    });
+
+    it('execute with absolute font path', function () {
+        let content = Buffer.from(
+            "body{ background: red;} @font-face {font-family: myFirstFont; src: url('/fonts/sansation_light.woff');}"
+        );
+        let result = step(new builder.File('foo.css', 'foo.css', content), {paths: {out: '/foo/bar/', root: '/foo/'}});
+
+        expect(result.name).toBe('foo.css');
+        expect(result.module).toBe('foo.css');
+        expect(result.additionalFiles.length).toBe(0);
+        expect(result.content.toString()).toBe(content.toString());
+    });
+});

--- a/src/Builder/Step/CssFontRewriteStep.php
+++ b/src/Builder/Step/CssFontRewriteStep.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * @copyright 2018 Hostnet B.V.
+ */
+declare(strict_types=1);
+
+namespace Hostnet\Component\Resolver\Builder\Step;
+
+use Hostnet\Component\Resolver\Builder\AbstractBuildStep;
+
+class CssFontRewriteStep extends AbstractBuildStep
+{
+    public function acceptedStates(): array
+    {
+        return [self::FILE_READY];
+    }
+
+    public function resultingState(): int
+    {
+        return self::FILE_READY;
+    }
+
+    public function acceptedExtension(): string
+    {
+        return '.css';
+    }
+
+    public function resultingExtension(): string
+    {
+        return '.css';
+    }
+
+    public function getJsModule(): string
+    {
+        return __DIR__ . '/../js/steps/css_rewrite.js';
+    }
+}

--- a/src/Builder/js/steps/css_rewrite.js
+++ b/src/Builder/js/steps/css_rewrite.js
@@ -1,0 +1,24 @@
+let path = require('path');
+
+module.exports = function (file, config) {
+    let content = file.content.toString().replace(/@font-face\s*{([^}]+)}/g, function (match, content) {
+        let rewrittenContent = content.replace(/url\(('([^']+)'|"([^"]+)")\)/g, function (match, quoted, u1, u2) {
+            let originalFile = u1 || u2;
+
+            // If the font was absolute, leave it be since it must be included in the application itself.
+            if (path.isAbsolute(originalFile)) {
+                return match;
+            }
+
+            let cssPath = config.paths.out + 'fonts/' + path.basename(originalFile);
+            let fontFile = path.normalize(path.join(config.paths.root, path.dirname(file.name), originalFile));
+
+            file.addAdditionalFile(cssPath, [fontFile]);
+
+            return 'url(' + JSON.stringify(path.relative(config.paths.out, cssPath)) + ')';
+        });
+        return '@font-face {' + rewrittenContent + '}';
+    });
+
+    return file.update(Buffer.from(content));
+};

--- a/src/Plugin/CssFontRewitePlugin.php
+++ b/src/Plugin/CssFontRewitePlugin.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @copyright 2018 Hostnet B.V.
+ */
+declare(strict_types=1);
+
+namespace Hostnet\Component\Resolver\Plugin;
+
+use Hostnet\Component\Resolver\Builder\Step\CssFontRewriteStep;
+use Hostnet\Component\Resolver\Builder\Step\IdentityBuildStep;
+
+/**
+ * Add support for re-writing font files in .css files so they end up in the correct folder and are referenced
+ * correctly.
+ */
+final class CssFontRewitePlugin implements PluginInterface
+{
+    public function activate(PluginApi $plugin_api): void
+    {
+        $plugin_api->addBuildStep(new CssFontRewriteStep());
+
+        $plugin_api->addBuildStep(new IdentityBuildStep('.otf'));
+        $plugin_api->addBuildStep(new IdentityBuildStep('.ttf'));
+        $plugin_api->addBuildStep(new IdentityBuildStep('.woff'));
+        $plugin_api->addBuildStep(new IdentityBuildStep('.woff2'));
+    }
+}

--- a/test/Builder/Step/CssFontRewriteStepTest.php
+++ b/test/Builder/Step/CssFontRewriteStepTest.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @copyright 2018 Hostnet B.V.
+ */
+declare(strict_types=1);
+
+namespace Hostnet\Component\Resolver\Builder\Step;
+
+use Hostnet\Component\Resolver\Builder\AbstractBuildStep;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Hostnet\Component\Resolver\Builder\Step\CssFontRewriteStep
+ */
+class CssFontRewriteStepTest extends TestCase
+{
+    public function testGeneric(): void
+    {
+        $step = new CssFontRewriteStep();
+
+        self::assertSame([AbstractBuildStep::FILE_READY], $step->acceptedStates());
+        self::assertSame(AbstractBuildStep::FILE_READY, $step->resultingState());
+        self::assertSame('.css', $step->acceptedExtension());
+        self::assertSame('.css', $step->resultingExtension());
+        self::assertContains('js/steps/css_rewrite.js', $step->getJsModule());
+    }
+}

--- a/test/Plugin/CssFontRewitePluginTest.php
+++ b/test/Plugin/CssFontRewitePluginTest.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * @copyright 2018 Hostnet B.V.
+ */
+declare(strict_types=1);
+
+namespace Hostnet\Component\Resolver\Plugin;
+
+use Hostnet\Component\Resolver\Builder\AbstractBuildStep;
+use Hostnet\Component\Resolver\Builder\Step\CssFontRewriteStep;
+use Hostnet\Component\Resolver\Builder\Step\IdentityBuildStep;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+
+/**
+ * @covers \Hostnet\Component\Resolver\Plugin\CssFontRewitePlugin
+ */
+class CssFontRewitePluginTest extends TestCase
+{
+    public function testActivate()
+    {
+        $css_font_rewite_plugin = new CssFontRewitePlugin();
+
+        $plugin_api = $this->prophesize(PluginApi::class);
+        $plugin_api->addBuildStep(Argument::type(CssFontRewriteStep::class))->shouldBeCalled();
+        $plugin_api->addBuildStep(Argument::that(function (AbstractBuildStep $step) {
+            return $step instanceof IdentityBuildStep
+                && \in_array($step->acceptedExtension(), ['.otf', '.ttf', '.woff', '.woff2'], true);
+        }))->shouldBeCalled();
+
+        $css_font_rewite_plugin->activate($plugin_api->reveal());
+    }
+}


### PR DESCRIPTION
With this change a new plugin is added which can rewrite and also provider the font files in css files. This will emit them together with the css when changed so you can package fonts with a the css in a lib and they will work.