### PR TITLE
Use module name instead of path when creating file

### DIFF
--- a/src/Builder/js/build.js
+++ b/src/Builder/js/build.js
@@ -44,7 +44,7 @@ let File = function (name, module, content, outputFile) {
 };
 
 File.fromBuildFile = function (buildFile, content) {
-    return new File(buildFile.path, buildFile.moduleName, content, buildFile.path);
+    return new File(buildFile.path, buildFile.moduleName, content, buildFile.moduleName);
 };
 
 function mkdirRecursive(rootDir, pathToCreate) {


### PR DESCRIPTION
The path contains the source file, but in this case you are interested in the output file. This is the moduleName. Else you will end up with the sources folder in the output name.