### PR TITLE
Buildable file is not exposed

### DIFF
--- a/src/Builder/js/build.js
+++ b/src/Builder/js/build.js
@@ -161,7 +161,11 @@ function compileFile(buildableFile, config, logger) {
                         );
                     }
 
-                    resolve(require(steps[j])(file, config, (file) => compileFile(file, config, logger)));
+                    resolve(require(steps[j])(
+                        file,
+                        config,
+                        (file) => compileFile(new BuildableFile(file), config, logger)
+                    ));
                 } catch (err) {
                     reject(err);
                 }


### PR DESCRIPTION
Because of the changes creating the file objects, it is no longer possible to pass an array and since the `BuildableFile` is not exposed, the callable can also just accept a string and wrap that.