### PR TITLE
Do not use windows line endings in css paths

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,6 +25,8 @@ install:
   - sc config wuauserv start= auto
   - net start wuauserv
   - ps: cinst -y php --version ((choco search php --exact --all-versions -r | Select-String -pattern $Env:PHP_VERSION | sort { [version]($_ -split '\|' | select -last 1) } -Descending | Select-Object -first 1) -replace '[php|]','')
+  - ps: cinst node 10.4.1
+  - ps: cinst yarn 1.7.0
   - cd c:\tools\php71
   - copy php.ini-production php.ini
   - echo date.timezone="UTC" >> php.ini
@@ -40,3 +42,4 @@ install:
 test_script:
   - cd C:\projects\asset-lib
   - vendor\bin\phpunit.bat
+  - yarn test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,10 @@ shallow_clone: false
 platform: 'x86'
 clone_folder: C:\projects\asset-lib
 
+cache:
+  - node_modules
+  - '%LOCALAPPDATA%/Yarn'
+
 branches:
   except:
     - gh-pages

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ clone_folder: C:\projects\asset-lib
 cache:
   - node_modules
   - '%LOCALAPPDATA%/Yarn'
+  - '%LOCALAPPDATA%\Composer\files'
 
 branches:
   except:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,9 +24,8 @@ install:
   - SET PATH=C:\Program Files\OpenSSL;%PATH%
   - sc config wuauserv start= auto
   - net start wuauserv
+  - ps: Install-Product node 10
   - ps: cinst -y php --version ((choco search php --exact --all-versions -r | Select-String -pattern $Env:PHP_VERSION | sort { [version]($_ -split '\|' | select -last 1) } -Descending | Select-Object -first 1) -replace '[php|]','')
-  - ps: cinst node 10.4.1
-  - ps: cinst yarn 1.7.0
   - cd c:\tools\php71
   - copy php.ini-production php.ini
   - echo date.timezone="UTC" >> php.ini
@@ -37,6 +36,7 @@ install:
   - SET PATH=C:\tools\php71;%PATH%
   - php -r "readfile('http://getcomposer.org/installer');" | php
   - php composer.phar install --prefer-dist --no-interaction
+  - yarn install
 
 ## Run the actual test
 test_script:

--- a/spec/fixtures/additional.js
+++ b/spec/fixtures/additional.js
@@ -1,6 +1,8 @@
+let path = require('path');
+
 module.exports = function (file) {
     if (file.name.endsWith('foo.js')) {
-        file.addAdditionalFile('/bar.js', [__dirname + '/input/bar.js']);
+        file.addAdditionalFile('/bar.js', [path.join(__dirname, 'input', 'bar.js')]);
     }
 
     return file;

--- a/spec/steps/css_rewrite.spec.js
+++ b/spec/steps/css_rewrite.spec.js
@@ -1,4 +1,5 @@
 let builder = require('../../src/Builder/js/build');
+let path = require('path');
 
 describe("css_rewrite.js", function () {
     let step = require('../../src/Builder/js/steps/css_rewrite');

--- a/spec/steps/css_rewrite.spec.js
+++ b/spec/steps/css_rewrite.spec.js
@@ -17,10 +17,10 @@ describe("css_rewrite.js", function () {
         expect(result.module).toBe('foo.css');
 
         expect(result.additionalFiles.length).toBe(1);
-        expect(result.additionalFiles[0].outputFile).toBe('/foo/bar/fonts/sansation_light.woff');
+        expect(result.additionalFiles[0].outputFile).toBe('/foo/bar/fonts/sansation_light.woff'.replace(/\//g, path.sep));
         expect(result.additionalFiles[0].inputFiles.length).toBe(1);
 
-        expect(result.additionalFiles[0].inputFiles[0].path).toBe('/foo/sansation_light.woff');
+        expect(result.additionalFiles[0].inputFiles[0].path).toBe('/foo/sansation_light.woff'.replace(/\//g, path.sep));
         expect(result.additionalFiles[0].inputFiles[0].extension).toBe('.woff');
         expect(result.additionalFiles[0].inputFiles[0].needsRebuild).toBe(true);
         expect(result.additionalFiles[0].inputFiles[0].skipFileSteps).toBe(false);
@@ -43,10 +43,10 @@ describe("css_rewrite.js", function () {
         expect(result.module).toBe('foo.css');
 
         expect(result.additionalFiles.length).toBe(1);
-        expect(result.additionalFiles[0].outputFile).toBe('/foo/bar/fonts/sansation_light.woff');
+        expect(result.additionalFiles[0].outputFile).toBe('/foo/bar/fonts/sansation_light.woff'.replace(/\//g, path.sep));
         expect(result.additionalFiles[0].inputFiles.length).toBe(1);
 
-        expect(result.additionalFiles[0].inputFiles[0].path).toBe('/foo/sansation_light.woff');
+        expect(result.additionalFiles[0].inputFiles[0].path).toBe('/foo/sansation_light.woff'.replace(/\//g, path.sep));
         expect(result.additionalFiles[0].inputFiles[0].extension).toBe('.woff');
         expect(result.additionalFiles[0].inputFiles[0].needsRebuild).toBe(true);
         expect(result.additionalFiles[0].inputFiles[0].skipFileSteps).toBe(false);
@@ -69,10 +69,10 @@ describe("css_rewrite.js", function () {
         expect(result.module).toBe('assets/foo/bar.less');
 
         expect(result.additionalFiles.length).toBe(1);
-        expect(result.additionalFiles[0].outputFile).toBe('public/dev/fonts/font.woff');
+        expect(result.additionalFiles[0].outputFile).toBe('public/dev/fonts/font.woff'.replace(/\//g, path.sep));
         expect(result.additionalFiles[0].inputFiles.length).toBe(1);
 
-        expect(result.additionalFiles[0].inputFiles[0].path).toBe('/foo/bar/some/folder/fonts/font.woff');
+        expect(result.additionalFiles[0].inputFiles[0].path).toBe('/foo/bar/some/folder/fonts/font.woff'.replace(/\//g, path.sep));
         expect(result.additionalFiles[0].inputFiles[0].extension).toBe('.woff');
         expect(result.additionalFiles[0].inputFiles[0].needsRebuild).toBe(true);
         expect(result.additionalFiles[0].inputFiles[0].skipFileSteps).toBe(false);

--- a/src/Builder/js/steps/css_rewrite.js
+++ b/src/Builder/js/steps/css_rewrite.js
@@ -17,6 +17,9 @@ module.exports = function (file, config) {
 
             let relativePath = path.relative(path.dirname(path.join(config.paths.out, file.outputFile)), cssPath);
 
+            // make sure to always use the '/' separator, since that is what CSS expects
+            relativePath = relativePath.replace(new RegExp('\\' + path.sep, 'g'), '/');
+
             return 'url(' + JSON.stringify(relativePath) + ')';
         });
         return '@font-face {' + rewrittenContent + '}';


### PR DESCRIPTION
Do not use windows line endings in css paths. This breaks the CSS.