### PR TITLE
Upgraded less to 3.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "brotli": "1.3.2",
     "clean-css": "^4.1.9",
-    "less": "^2.7.0",
+    "less": "^3.8.0",
     "split": "^1.0.1",
     "typescript": "^2.5.0",
     "uglify-js": "^3.1.0"

--- a/spec/steps/less.spec.js
+++ b/spec/steps/less.spec.js
@@ -14,6 +14,19 @@ describe("less.js", function () {
         expect(result.content.toString()).toBe('body {\n  background: red;\n}\nbody a {\n  font-size: 12px;\n}\n');
     });
 
+    it('execute with JS', function () {
+        let step = require('../../src/Builder/js/steps/less');
+        let result = step(new builder.File(
+            'foo.less',
+            'foo.less',
+            Buffer.from("@foo: `42`; body { margin: '@{foo}px'; }")
+        ));
+
+        expect(result.name).toBe('foo.less');
+        expect(result.module).toBe('foo.less');
+        expect(result.content.toString()).toBe("body {\n  margin: '42px';\n}\n");
+    });
+
     it('on error', function () {
         let step = require('../../src/Builder/js/steps/less');
         try {

--- a/src/Builder/js/steps/less.js
+++ b/src/Builder/js/steps/less.js
@@ -5,7 +5,8 @@ module.exports = function (file) {
     less.render(file.content.toString(), {
         filename: file.name,
         syncImport: true,
-        relativeUrls: true
+        relativeUrls: true,
+        javascriptEnabled: true
     }, function (error, output) {
         if (null !== error) {
             throw error.message + ' in ' + error.filename + ' on line ' + error.line;


### PR DESCRIPTION
Upgraded less to latest version (as of writing). Also added test to make sure the JS in the less still works. From 3.0.0 and up, this is disabled by default. (see http://lesscss.org/usage/#less-options-enable-inline-javascript-deprecated- )