### PR TITLE
Allow export * from and resolving a directory with index files.

### DIFF
--- a/spec/require.spec.js
+++ b/spec/require.spec.js
@@ -215,6 +215,16 @@ describe("Require.js module register method test", function () {
         expect(lib.require('relfoo')).toEqual('BAR');
     });
 
+    it("with paths that have an index", function() {
+        lib.register("shared/multi/index", function(define, require, module, exports) {
+            define([], function () {
+                return 'BAR';
+            });
+        });
+
+        expect(lib.require('shared/multi')).toEqual('BAR');
+    });
+
     it("with unknown require", function() {
         try {
             lib.require('somemodule');

--- a/src/Builder/js/require.js
+++ b/src/Builder/js/require.js
@@ -131,6 +131,9 @@
     };
 
     window.register = function (name, parent, initializer) {
+        if (name.substr(name.length - 6) === '/index') {
+            name = name.substr(0, name.length - 6);
+        }
         if (_modules[name]) {
             if (typeof console !== 'undefined' && typeof console.warn === 'function') {
                 console.warn(new ModuleRedeclareError(name));

--- a/src/Import/BuiltIn/TsImportCollector.php
+++ b/src/Import/BuiltIn/TsImportCollector.php
@@ -49,12 +49,12 @@ final class TsImportCollector implements ImportCollectorInterface
     public function collect(string $cwd, File $file, ImportCollection $imports): void
     {
         $content = file_get_contents(File::makeAbsolutePath($file->path, $cwd));
-        $n       = preg_match_all('/import([^;\'"]*from)?\s+["\'](.*?)["\'];/', $content, $matches);
+        $n       = preg_match_all('/(import|export)([^;\'"]*from)?\s+["\'](.*?)["\'];/', $content, $matches);
 
         $this->js_import_collector->collect($cwd, $file, $imports);
 
         for ($i = 0; $i < $n; $i++) {
-            $path = $matches[2][$i];
+            $path = $matches[3][$i];
 
             try {
                 $import = $this->nodejs_resolver->asRequire($path, $file);

--- a/src/Import/Nodejs/FileResolver.php
+++ b/src/Import/Nodejs/FileResolver.php
@@ -54,7 +54,7 @@ final class FileResolver implements FileResolverInterface
         }
 
         if ($name[0] === '.' && ($name[1] === '/' || ($name[1] === '.' && $name[2] === '/'))) {
-            // 3. If X begins with './' or '/' or '../'
+            // 3. If X begins with './' or '../'
             // a. LOAD_AS_FILE(Y + X)
             try {
                 $f = new File($this->asFile($parent->dir . '/' . $name));
@@ -120,9 +120,12 @@ final class FileResolver implements FileResolverInterface
         $path = File::makeAbsolutePath($name, $this->config->getProjectRoot());
 
         // 1. If X/index.js is a file, load X/index.js as JavaScript text.  STOP
-        if (is_file($path . '/index.js')) {
-            return File::clean($name . '/index.js');
+        foreach ($this->extensions as $ext) {
+            if (is_file($path . '/index' . $ext)) {
+                return File::clean($name . '/index'. $ext);
+            }
         }
+
         // 2. If X/index.json is a file, parse X/index.json to a JavaScript object. STOP
         if (is_file($path . '/index.json')) {
             return File::clean($name . '/index.json');

--- a/test/Builder/var-saved/build_config.json
+++ b/test/Builder/var-saved/build_config.json
@@ -1,22 +1,18 @@
 {
-    "checksum": "16bead9140c80ba60459e4c2e3d9031c",
+    "checksum": "64b2ce65cb4d4309f7279cacf3fc9379",
     "mapping": {
         ".js": ".js"
     },
     "paths": {
-        "root": "\/home\/hiedema\/projects\/asset-lib\/test\/Builder\/",
+        "root": "",
         "out": "dist\/",
-        "cache": "\/home\/hiedema\/projects\/asset-lib\/test\/Builder\/var-saved\/"
+        "cache": ""
     },
     "build": {
         ".js": [
-            [
-                "\/home\/hiedema\/projects\/asset-lib\/src\/Builder\/Step\/..\/js\/steps\/identity.js"
-            ],
             [],
-            [
-                "\/home\/hiedema\/projects\/asset-lib\/src\/Builder\/Writer\/..\/js\/writers\/generic.js"
-            ]
+            [],
+            []
         ]
     }
 }

--- a/test/Builder/var-saved/build_config.json
+++ b/test/Builder/var-saved/build_config.json
@@ -1,18 +1,22 @@
 {
-    "checksum": "64b2ce65cb4d4309f7279cacf3fc9379",
+    "checksum": "16bead9140c80ba60459e4c2e3d9031c",
     "mapping": {
         ".js": ".js"
     },
     "paths": {
-        "root": "",
+        "root": "\/home\/hiedema\/projects\/asset-lib\/test\/Builder\/",
         "out": "dist\/",
-        "cache": ""
+        "cache": "\/home\/hiedema\/projects\/asset-lib\/test\/Builder\/var-saved\/"
     },
     "build": {
         ".js": [
+            [
+                "\/home\/hiedema\/projects\/asset-lib\/src\/Builder\/Step\/..\/js\/steps\/identity.js"
+            ],
             [],
-            [],
-            []
+            [
+                "\/home\/hiedema\/projects\/asset-lib\/src\/Builder\/Writer\/..\/js\/writers\/generic.js"
+            ]
         ]
     }
 }

--- a/test/Import/BuiltIn/TsImportCollectorTest.php
+++ b/test/Import/BuiltIn/TsImportCollectorTest.php
@@ -82,6 +82,9 @@ class TsImportCollectorTest extends TestCase
                 new Module('module_package_dir', 'node_modules/module_package_dir/src/index.js')
             ),
             new Import('jquery', new Module('jquery', 'node_modules/jquery/jquery.js')),
+            new Import('./Alias', new File('resolver/ts/import-syntax/Alias.ts')),
+            new Import('./DoubleQuote', new File('resolver/ts/import-syntax/DoubleQuote.ts')),
+            new Import('./Simple', new File('resolver/ts/import-syntax/Simple.ts'))
         ], $imports->getImports());
 
         self::assertEquals([], $imports->getResources());

--- a/test/fixtures/resolver/ts/import-syntax/main.ts
+++ b/test/fixtures/resolver/ts/import-syntax/main.ts
@@ -17,6 +17,7 @@ import $ from "jquery";
 import i = require("./Import");
 import Array from "./Array";
 
-export * from "./Alias";
+export {A as Alias} from "./Alias";
 export * from "./DoubleQuote";
 export * from "./Simple";
+

--- a/test/fixtures/resolver/ts/import-syntax/main.ts
+++ b/test/fixtures/resolver/ts/import-syntax/main.ts
@@ -16,3 +16,7 @@ import "module_package_dir";
 import $ from "jquery";
 import i = require("./Import");
 import Array from "./Array";
+
+export * from "./Alias";
+export * from "./DoubleQuote";
+export * from "./Simple";

--- a/test/fixtures/resolver/ts/import-syntax/main.ts
+++ b/test/fixtures/resolver/ts/import-syntax/main.ts
@@ -21,3 +21,18 @@ export {A as Alias} from "./Alias";
 export * from "./DoubleQuote";
 export * from "./Simple";
 
+export { ZipCodeValidator as mainValidator };
+export default "123";
+export = ZipCodeValidator;
+export var t = something + 1;
+
+export default function (s: string) {
+    return s.length === 5 && numberRegexp.test(s);
+}
+
+export default class ZipCodeValidator {
+    static numberRegexp = /^[0-9]+$/;
+    isAcceptable(s: string) {
+        return s.length === 5 && ZipCodeValidator.numberRegexp.test(s);
+    }
+}


### PR DESCRIPTION
Fixes #84 and #85

- `export * from "./file"` is now possible
- `import { X, Y, Z } from "some/directory` that has an `index` file now works too.
