### PR TITLE
Allow relative imports from dirs and without extensions

### DIFF
--- a/spec/require.spec.js
+++ b/spec/require.spec.js
@@ -225,14 +225,22 @@ describe("Require.js module register method test", function () {
         expect(lib.require('shared/multi')).toEqual('BAR');
     });
 
-    it("with paths that have an index", function() {
+    it("with referenced modules without extension (implicit type)", function() {
         lib.register("shared/multi/henk.js", function(define, require, module, exports) {
             define([], function () {
                 return 'BAR';
             });
         });
+        lib.register("shared/multi/with-index/index.js", function(define, require, module, exports) {
+            define([], function () {
+                return 'FOO';
+            });
+        });
 
         expect(lib.require('shared/multi/henk')).toEqual('BAR');
+        expect(lib.require('shared/multi/with-index')).toEqual('FOO');
+        expect(lib.require('shared/multi/with-index/index')).toEqual('FOO');
+        expect(lib.require('shared/multi/with-index/index.js')).toEqual('FOO');
     });
 
     it("with unknown require", function() {

--- a/spec/require.spec.js
+++ b/spec/require.spec.js
@@ -225,6 +225,16 @@ describe("Require.js module register method test", function () {
         expect(lib.require('shared/multi')).toEqual('BAR');
     });
 
+    it("with paths that have an index", function() {
+        lib.register("shared/multi/henk.js", function(define, require, module, exports) {
+            define([], function () {
+                return 'BAR';
+            });
+        });
+
+        expect(lib.require('shared/multi/henk')).toEqual('BAR');
+    });
+
     it("with unknown require", function() {
         try {
             lib.require('somemodule');

--- a/src/Builder/js/require.js
+++ b/src/Builder/js/require.js
@@ -119,6 +119,14 @@
     };
 
     window.require = function (name) {
+        var i, knownSuffixes = ['', '.js', '/index', '/index.js'];
+        for (i = 0; i < knownSuffixes.length; i++) {
+            if (_modules[name + knownSuffixes[i]]) {
+                name = name + knownSuffixes[i];
+                break;
+            }
+        }
+
         if (!_modules[name]) {
             throw new RequireError(name);
         }


### PR DESCRIPTION
Including the file `./some/dir/my-file.js` can now be included as `./some/dir/my-file`.

calling `require` will now always try to resolve 4 different modules in the following order (call order is important here):
 - no suffix (exact match)
 - `*.js` (implicit .js file, default node/common-js behavior)
 - `*/index` (implicit index - can be a file or a directory)
 - `*/index.js` (implicit index.js, default node/common-js behavior)

(where `*` is the argument passed to `require()`)

Calling directories with a `package.json` file that defines a `main` entry point _should_ already be taken care of in a previous step.