### PR TITLE
Remove symfony/phpunit-bridge

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,10 @@
         "symfony/event-dispatcher": "^4.0.0"
     },
     "require-dev": {
-        "hostnet/phpcs-tool":     "^8.3.3",
-        "mikey179/vfsstream":     "^1.6.6",
-        "phpunit/phpunit":        "^8.1.3",
-        "symfony/phpunit-bridge": "^4.2.8",
-        "symfony/process":        "^4.2.8"
+        "hostnet/phpcs-tool": "^8.3.3",
+        "mikey179/vfsstream": "^1.6.6",
+        "phpunit/phpunit":    "^8.1.3",
+        "symfony/process":    "^4.2.8"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,8 +15,4 @@
             <directory>./src</directory>
         </whitelist>
     </filter>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
-    </listeners>
 </phpunit>


### PR DESCRIPTION
Removes symfony/phpunit-bridge so the build does not fail on deprecation warnings anymore.