### PR TITLE
Make symfony 5 compatible, symfony/process should be required.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,14 +7,14 @@
         "php":                      ">=7.2",
         "psr/log":                  "^1.0.0",
         "psr/simple-cache":         "^1.0.0",
-        "symfony/console":          "^4.0.0",
-        "symfony/event-dispatcher": "^4.0.0"
+        "symfony/console":          "^4.0.0 || ^5.0.0",
+        "symfony/event-dispatcher": "^4.0.0 || ^5.0.0",
+        "symfony/process":          "^4.2.8 || ^5.0.0"
     },
     "require-dev": {
         "hostnet/phpcs-tool": "^8.3.3",
         "mikey179/vfsstream": "^1.6.6",
-        "phpunit/phpunit":    "^8.1.3",
-        "symfony/process":    "^4.2.8"
+        "phpunit/phpunit":    "^8.1.3"
     },
     "autoload": {
         "psr-4": {

--- a/src/Builder/Bundler.php
+++ b/src/Builder/Bundler.php
@@ -64,7 +64,12 @@ final class Bundler implements BundlerInterface
         $process = new Process($cmd, $this->config->getProjectRoot(), [
             'NODE_PATH' => $this->config->getNodeJsExecutable()->getNodeModulesLocation(),
         ], json_encode($build_files));
-        $process->inheritEnvironmentVariables();
+
+        // Backwards compatible with symfony before SF4.4 where this has become implicit and should not be called.
+        // https://github.com/symfony/symfony/pull/32475
+        if (\method_exists($process, 'inheritEnvironmentVariables')) {
+            $process->inheritEnvironmentVariables();
+        }
 
         $reader = new OutputReader($this->config->getReporter());
 


### PR DESCRIPTION
Wrapped method calls that are required in symfony 4 but no longer exist in symfony 5 in method exists.

Added symfony process component to the require instead of the require-dev because we're actively using it, so use without the bundle would break this. 